### PR TITLE
Remove number type check from formatNumber()

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -27,12 +27,6 @@ function assertIsDate(date, errMsg) {
     }
 }
 
-function assertIsNumber(num, errMsg) {
-    if (typeof num !== 'number') {
-        throw new TypeError(errMsg);
-    }
-}
-
 export default {
     statics: {
         filterFormatOptions: function (obj) {
@@ -85,7 +79,6 @@ export default {
     },
 
     formatNumber: function (num, options) {
-        assertIsNumber(num, 'A number must be provided to formatNumber()');
         return this._format('number', num, options);
     },
 


### PR DESCRIPTION
This removes an unnecessary type check from `formatNumber()` since the underlying `Intl.NumberFormat#format()` method will never throw.

_Note:_ The point of the type check was to provide a more useful, higher-level error message to the users of React Intl so they know where the error is coming from. The date type checks are still useful since they are more descriptive than what the underlying `format()` method will throw.