### PR TITLE
Change React Intl Components to be self-closing

### DIFF
--- a/example/src/components.js
+++ b/example/src/components.js
@@ -18,13 +18,13 @@ var Another = React.createClass({
       {this.formatDate(new Date(), "time-style")}
 
       <h3>IntlDate component with custom format</h3>
-      <IntlDate format="time-style">{new Date()}</IntlDate>
+      <IntlDate value={new Date()} format="time-style" />
 
       <h3>formatNumber() method with custom format</h3>
       {this.formatNumber(600, "eur")}
 
       <h3>IntlNumber component with custom format</h3>
-      <IntlNumber format="eur">{600}</IntlNumber>
+      <IntlNumber value={600} format="eur" />
 
       <h3>formatMessage() method</h3>
       {this.formatMessage(this.getIntlMessage('SHORT'), {
@@ -35,13 +35,11 @@ var Another = React.createClass({
       })}
 
       <h3>IntlMessage component</h3>
-      <IntlMessage
+      <IntlMessage message={this.getIntlMessage('SHORT')}
           product="apples"
           price={2000.15}
           deadline={new Date()}
-          timeZone="UTC">
-        {this.getIntlMessage('SHORT')}
-      </IntlMessage>
+          timeZone="UTC" />
     </div>;
   }
 });
@@ -86,7 +84,7 @@ var Container = global.ContainerComponent = React.createClass({
         {this.formatRelative(this.props.someTimestamp)}
 
         <h2>IntlRelative component</h2>
-        <IntlRelative>{this.props.someTimestamp}</IntlRelative>
+        <IntlRelative value={this.props.someTimestamp} />
 
         <hr/>
 
@@ -102,11 +100,11 @@ var Container = global.ContainerComponent = React.createClass({
 
         <h2>IntlDate component</h2>
         <h3>default</h3>
-        <IntlDate>{this.props.someTimestamp}</IntlDate>
+        <IntlDate value={this.props.someTimestamp} />
         <h3>with options</h3>
-        <IntlDate hour="numeric" minute="numeric">{this.props.someTimestamp}</IntlDate>
+        <IntlDate value={this.props.someTimestamp} hour="numeric" minute="numeric" />
         <h3>with custom format</h3>
-        <IntlDate format="time-style">{this.props.someTimestamp}</IntlDate>
+        <IntlDate value={this.props.someTimestamp} format="time-style" />
 
         <hr/>
 
@@ -122,11 +120,11 @@ var Container = global.ContainerComponent = React.createClass({
 
         <h2>IntlNumber component</h2>
         <h3>default</h3>
-        <IntlNumber>{400}</IntlNumber>
+        <IntlNumber value={400} />
         <h3>with options</h3>
-        <IntlNumber style="percent">{0.40}</IntlNumber>
+        <IntlNumber value={0.40} style="percent" />
         <h3>with custom format</h3>
-        <IntlNumber format="eur">{400}</IntlNumber>
+        <IntlNumber value={400} format="eur" />
 
         <hr/>
 
@@ -141,45 +139,57 @@ var Container = global.ContainerComponent = React.createClass({
         })}
 
         <h3>IntlMessage component</h3>
-        <IntlMessage
+        <IntlMessage message={this.getIntlMessage('LONG')}
             product="oranges"
             price={40000.004}
             deadline={this.props.someTimestamp}
-            timeZone="UTC">
-          {this.getIntlMessage('LONG')}
-        </IntlMessage>
+            timeZone="UTC" />
 
         <hr/>
 
-        <h1>HTMLMessage</h1>
+        <h1>Message with HTML</h1>
 
-        <h3>IntlHTMLMessage component</h3>
-        <IntlHTMLMessage
-            product="oranges"
-            price={40000.004}
-            deadline={this.props.someTimestamp}
-            timeZone="UTC">
-          {this.getIntlMessage('LONG_WITH_HTML')}
-        </IntlHTMLMessage>
+        <h3>IntlMessage component with HTML</h3>
+        <IntlMessage message={this.getIntlMessage('LONG')}
+          product={<strong>oranges</strong>}
+          price={40000.004}
+          deadline={this.props.someTimestamp}
+          timeZone="UTC" />
 
-        <h3>IntlHTMLMessage component with XSS attempt</h3>
-        <IntlHTMLMessage
+        <h3>IntlMessage component with XSS attempt</h3>
+        <IntlMessage message={this.getIntlMessage('LONG')}
             product="oranges</span><script>alert('pwnd!');</script>"
             price={40000.004}
             deadline={this.props.someTimestamp}
-            timeZone="UTC">
-          {this.getIntlMessage('LONG_WITH_HTML')}
-        </IntlHTMLMessage>
+            timeZone="UTC" />
 
-        <h3>IntlHTMLMessage component with custom tagName</h3>
-        <IntlHTMLMessage
-            __tagName="p"
+        <h3>IntlMessage component with custom tagName</h3>
+        <IntlMessage tagName="p" message={this.getIntlMessage('LONG')}
+            product={<strong>oranges</strong>}
+            price={40000.004}
+            deadline={this.props.someTimestamp}
+            timeZone="UTC" />
+
+        <h3>IntlHTMLMessage component</h3>
+        <IntlHTMLMessage message={this.getIntlMessage('LONG_WITH_HTML')}
             product="oranges"
             price={40000.004}
             deadline={this.props.someTimestamp}
-            timeZone="UTC">
-          {this.getIntlMessage('LONG_WITH_HTML')}
-        </IntlHTMLMessage>
+            timeZone="UTC" />
+
+        <h3>IntlHTMLMessage component with XSS attempt</h3>
+        <IntlHTMLMessage message={this.getIntlMessage('LONG_WITH_HTML')}
+            product="oranges</span><script>alert('pwnd!');</script>"
+            price={40000.004}
+            deadline={this.props.someTimestamp}
+            timeZone="UTC" />
+
+        <h3>IntlHTMLMessage component with custom tagName</h3>
+        <IntlHTMLMessage tagName="p" message={this.getIntlMessage('LONG_WITH_HTML')}
+            product="oranges"
+            price={40000.004}
+            deadline={this.props.someTimestamp}
+            timeZone="UTC" />
 
         <hr/>
 

--- a/src/components/date.js
+++ b/src/components/date.js
@@ -17,10 +17,16 @@ var IntlDate = React.createClass({
         ]
     },
 
+    propTypes: {
+        format: React.PropTypes.string,
+        value : React.PropTypes.any.isRequired
+    },
+
     render: function () {
         var props    = this.props;
-        var value    = props.children;
-        var defaults = props.format && this.getNamedFormat('date', props.format);
+        var value    = props.value;
+        var format   = props.format;
+        var defaults = format && this.getNamedFormat('date', format);
         var options  = IntlDate.filterFormatOptions(props, defaults);
 
         return React.DOM.span(null, this.formatDate(value, options));

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -6,43 +6,53 @@ import React from '../react';
 import escape from '../escape';
 import IntlMixin from '../mixin';
 
-function escapeProps(props) {
-    return Object.keys(props).reduce(function (escapedProps, name) {
-        var value = props[name];
-
-        // TODO: Can we force string coersion here? Or would that not be needed
-        // and possible mess with IntlMessageFormat?
-        if (typeof value === 'string') {
-            value = escape(value);
-        }
-
-        escapedProps[name] = value;
-        return escapedProps;
-    }, {});
-}
-
 var IntlHTMLMessage = React.createClass({
     displayName: 'IntlHTMLMessage',
     mixins     : [IntlMixin],
 
+    propTypes: {
+        tagName: React.PropTypes.string,
+        message: React.PropTypes.string.isRequired
+    },
+
     getDefaultProps: function () {
-        return {__tagName: 'span'};
+        return {tagName: 'span'};
     },
 
     render: function () {
-        var props        = this.props;
-        var tagName      = props.__tagName;
-        var message      = props.children;
-        var escapedProps = escapeProps(props);
+        var props   = this.props;
+        var tagName = props.tagName;
+        var message = props.message;
+
+        // Process all the props before they are used as values when formatting
+        // the ICU Message string. Since the formatted message will be injected
+        // via `innerHTML`, all String-based values need to be HTML-escaped. Any
+        // React Elements that are passed as props will be rendered to a static
+        // markup string that is presumed to be safe.
+        var values = Object.keys(props).reduce(function (values, name) {
+            var value = props[name];
+
+            if (typeof value === 'string') {
+                value = escape(value);
+            } else if (React.isValidElement(value)) {
+                value = React.renderToStaticMarkup(value);
+            }
+
+            values[name] = value;
+            return values;
+        }, {});
 
         // Since the message presumably has HTML in it, we need to set
         // `innerHTML` in order for it to be rendered and not escaped by React.
-        // To be safe, we are escaping all string prop values before formatting
-        // the message. It is assumed that the message is not UGC, and came from
+        // To be safe, all string prop values were escaped before formatting the
+        // message. It is assumed that the message is not UGC, and came from
         // the developer making it more like a template.
+        //
+        // Note: There's a perf impact of using this component since there's no
+        // way for React to do its virtual DOM diffing.
         return React.DOM[tagName]({
             dangerouslySetInnerHTML: {
-                __html: this.formatMessage(message, escapedProps)
+                __html: this.formatMessage(message, values)
             }
         });
     }

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -9,11 +9,70 @@ var IntlMessage = React.createClass({
     displayName: 'IntlMessage',
     mixins     : [IntlMixin],
 
+    propTypes: {
+        tagName: React.PropTypes.string,
+        message: React.PropTypes.string.isRequired
+    },
+
+    getDefaultProps: function () {
+        return {tagName: 'span'};
+    },
+
     render: function () {
         var props   = this.props;
-        var message = props.children;
+        var tagName = props.tagName;
+        var message = props.message;
 
-        return React.DOM.span(null, this.formatMessage(message, props));
+        // Creates a token with a random guid that should not be guessible or
+        // conflict with other parts of the `message` string.
+        var guid     = Math.floor(Math.random() * 0x10000000000).toString(16);
+        var token    = '@__ELEMENT_' + guid + '__@';
+        var elements = [];
+
+        // Iterates over the `props` to keep track of any React Element values
+        // so they can be represented by the `token` as a placeholder when the
+        // `message` is formatted. This allows the formatted message to then be
+        // broken-up into parts with references to the React Elements inserted
+        // back in.
+        var values = Object.keys(props).reduce(function (values, name) {
+            var value = props[name];
+
+            if (React.isValidElement(value)) {
+                values[name] = token;
+                elements.push(value);
+            } else {
+                values[name] = value;
+            }
+
+            return values;
+        }, {});
+
+        // Formats the `message` with the `values`, including the `token`
+        // placeholders for React Element values. Then the message is split into
+        // parts on each `token` sub-string.
+        var formattedMessage      = this.formatMessage(message, values);
+        var formattedMessageParts = formattedMessage.split(token);
+
+        // Using the formatted message's parts, an array of child React Elements
+        // is constructed so that React's virtual diffing can work properly. The
+        // React Elements that were put aside above are now inserted back into
+        // position so that React can render the message with any nested React
+        // Elements properly.
+        var children = formattedMessageParts.reduce(function (parts, part, i) {
+            if (part) {
+                parts.push(part);
+            }
+
+            var element = elements[i];
+            if (element) {
+                parts.push(element);
+            }
+
+            return parts;
+        }, []);
+
+        var elementArgs = [tagName, null].concat(children);
+        return React.createElement.apply(null, elementArgs);
     }
 });
 

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -25,9 +25,16 @@ var IntlMessage = React.createClass({
 
         // Creates a token with a random guid that should not be guessible or
         // conflict with other parts of the `message` string.
-        var guid     = Math.floor(Math.random() * 0x10000000000).toString(16);
-        var token    = '@__ELEMENT_' + guid + '__@';
-        var elements = [];
+        var guid       = Math.floor(Math.random() * 0x10000000000).toString(16);
+        var tokenRegex = new RegExp('(@__ELEMENT-' + guid + '-\\d__@)', 'g');
+        var elements   = {};
+
+        var generateToken = (function () {
+            var counter = 0;
+            return function () {
+                return '@__ELEMENT-' + guid + '-' + (counter += 1) + '__@';
+            };
+        }());
 
         // Iterates over the `props` to keep track of any React Element values
         // so they can be represented by the `token` as a placeholder when the
@@ -36,10 +43,12 @@ var IntlMessage = React.createClass({
         // back in.
         var values = Object.keys(props).reduce(function (values, name) {
             var value = props[name];
+            var token;
 
             if (React.isValidElement(value)) {
-                values[name] = token;
-                elements.push(value);
+                token           = generateToken();
+                values[name]    = token;
+                elements[token] = value;
             } else {
                 values[name] = value;
             }
@@ -48,28 +57,16 @@ var IntlMessage = React.createClass({
         }, {});
 
         // Formats the `message` with the `values`, including the `token`
-        // placeholders for React Element values. Then the message is split into
-        // parts on each `token` sub-string.
-        var formattedMessage      = this.formatMessage(message, values);
-        var formattedMessageParts = formattedMessage.split(token);
+        // placeholders for React Element values.
+        var formattedMessage = this.formatMessage(message, values);
 
-        // Using the formatted message's parts, an array of child React Elements
-        // is constructed so that React's virtual diffing can work properly. The
-        // React Elements that were put aside above are now inserted back into
-        // position so that React can render the message with any nested React
-        // Elements properly.
-        var children = formattedMessageParts.reduce(function (parts, part, i) {
-            if (part) {
-                parts.push(part);
-            }
-
-            var element = elements[i];
-            if (element) {
-                parts.push(element);
-            }
-
-            return parts;
-        }, []);
+        // Split the message into parts, and replace the token placeholder parts
+        // with references to the React Element values captured above. This
+        // approach allows messages to render with React Elements while keeping
+        // React's virtual diffing working properly.
+        var children = formattedMessage.split(tokenRegex).map(function (part) {
+            return elements[part] || part;
+        });
 
         var elementArgs = [tagName, null].concat(children);
         return React.createElement.apply(null, elementArgs);

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -18,10 +18,16 @@ var IntlNumber = React.createClass({
         ]
     },
 
+    propTypes: {
+        format: React.PropTypes.string,
+        value : React.PropTypes.any.isRequired
+    },
+
     render: function () {
         var props    = this.props;
-        var value    = props.children;
-        var defaults = props.format && this.getNamedFormat('number', props.format);
+        var value    = props.value;
+        var format   = props.format;
+        var defaults = format && this.getNamedFormat('number', format);
         var options  = IntlNumber.filterFormatOptions(props, defaults);
 
         return React.DOM.span(null, this.formatNumber(value, options));

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -15,10 +15,16 @@ var IntlRelative = React.createClass({
         ]
     },
 
+    propTypes: {
+        format: React.PropTypes.string,
+        value : React.PropTypes.any.isRequired
+    },
+
     render: function () {
         var props    = this.props;
-        var value    = props.children;
-        var defaults = props.format && this.getNamedFormat('relative', props.format);
+        var value    = props.value;
+        var format   = props.format;
+        var defaults = format && this.getNamedFormat('relative', format);
         var options  = IntlRelative.filterFormatOptions(props, defaults);
 
         return React.DOM.span(null, this.formatRelative(value, options));

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -17,10 +17,16 @@ var IntlTime = React.createClass({
         ]
     },
 
+    propTypes: {
+        format: React.PropTypes.string,
+        value : React.PropTypes.any.isRequired
+    },
+
     render: function () {
         var props    = this.props;
-        var value    = props.children;
-        var defaults = props.format && this.getNamedFormat('time', props.format);
+        var value    = props.value;
+        var format   = props.format;
+        var defaults = format && this.getNamedFormat('time', format);
         var options  = IntlTime.filterFormatOptions(props, defaults);
 
         return React.DOM.span(null, this.formatTime(value, options));

--- a/tests/smoke/smoke.js
+++ b/tests/smoke/smoke.js
@@ -27,8 +27,9 @@ describe('React Intl mixin', function () {
         var testNode = document.getElementById('test1');
 
         React.render(IntlNumber({
-            locales: ['es-AR']
-        }, 1000), testNode);
+            locales: ['es-AR'],
+            value: 1000
+        }), testNode);
 
         expect(testNode.firstChild.innerHTML).to.equal('1.000');
     });
@@ -53,9 +54,10 @@ describe('React Intl mixin', function () {
                 }
             },
 
+            value: price.value,
             format: 'currency',
             currency: price.currency
-        }, price.value), testNode);
+        }), testNode);
 
         expect(testNode.firstChild.innerHTML).to.equal('$99.95');
     });
@@ -98,17 +100,19 @@ describe('React Intl mixin', function () {
 
         React.render(IntlDate({
             locales: ['es-AR'],
+            value: Date.UTC(2014, 8, 22, 0, 0, 0, 0),
             weekday: 'long',
             timeZone: 'UTC'
-        }, Date.UTC(2014, 8, 22, 0, 0, 0, 0)), testNode);
+        }), testNode);
 
         expect(testNode.firstChild.innerHTML).to.contain('lunes');
 
         React.render(IntlDate({
             locales: ['en-US'],
+            value: 0,
             weekday: 'long',
             timeZone: 'UTC'
-        }, 0), testNode);
+        }), testNode);
 
         expect(testNode.firstChild.innerHTML).to.contain('Thursday');
     });
@@ -147,8 +151,9 @@ describe('React Intl mixin', function () {
 
         React.render(IntlMessage({
             locales: ['en-US'],
+            message: 'You have {numPhotos, plural, =0 {no photos} =1 {one photo} other {# photos}}.',
             numPhotos: 1
-        }, 'You have {numPhotos, plural, =0 {no photos} =1 {one photo} other {# photos}}.'), testNode);
+        }), testNode);
 
         expect(testNode.firstChild.innerHTML).to.equal('You have one photo.');
     });


### PR DESCRIPTION
This modifies all of the React Intl Components to be self-closing instead of relying on the nested child to be the value of interest. All of the components (beside Message and HTMLMessage) have a `value` prop:

```jsx
<FromattedNumber value={1000} />
```

The Message and HTMLMessage components use a `message` prop instead of `value`. Both of these components now support React Elements as prop values! This makes formatting message _much_ more powerful, and for the Message component, React will be able to use virtual DOM diffing. For the HTMLMessage component there will be a perf hit since the entire message must end up as a big HTML string that's then injected into the DOM via `dangerouslySetInnerHTML`.

```jsx
var msg = "Posted {ago}, {likes, plural, one{# like} other{# likes}}";

<FormattedMessage message={msg}
   ago={<FormattedRelative value={post.date} />}
   likes={post.likes} />
```

Details of the discussion on using nested children vs. self-closing elements, and supporting React Elements in messages is in #65.

Fixes #26