### PR TITLE
Update react dependency to: ">=0.11.2 <1.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "intl-format-cache": "2.0.4",
     "intl-messageformat": "1.0.4",
     "intl-relativeformat": "1.0.3",
-    "react": ">=0.11.2 <0.13.0"
+    "react": ">=0.11.2 <1.0.0"
   },
   "devDependencies": {
     "es5-shim": "^4.0.3",


### PR DESCRIPTION
This brings in support for react@0.13, plus any future pre-1.0 versions. React has a great back-compat track record, so it should be safe to do this. If an issue arrises, we can always back this down in a patch release.

Closes #79