### PR TITLE
Change `propsTypes` to `propTypes` in mixin.js

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -44,7 +44,7 @@ export default {
         }
     },
 
-    propsTypes       : typesSpec,
+    propTypes        : typesSpec,
     contextTypes     : typesSpec,
     childContextTypes: typesSpec,
 


### PR DESCRIPTION
This looks like a typo to me. It seems that it was intended to be `propTypes`.