### PR TITLE
Update package.son to be a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   "dependencies": {
     "intl-format-cache": "2.0.4",
     "intl-messageformat": "1.1.0",
-    "intl-relativeformat": "1.1.0",
-    "react": ">=0.11.2 <1.0.0"
+    "intl-relativeformat": "1.1.0"
+  },
+  "peerDependencies": {
+    "react": "^0.13.3"
   },
   "devDependencies": {
     "es5-shim": "^4.1.0",


### PR DESCRIPTION
Hi There,

This source for this fix was originally the react dev tools in Chrome failing to recognise components on the page, and showing an empty top-level tag.

The cause appeared to be 2 versions of react being present in my webpack created bundle. One the app specified version, and another being a beta 0.14 version that I tracked down to be a dependency of react-intl.

Have updated the package.json to specify react as a peer dependency so that bundling tools such as webpack, etc, don’t bundle react-intl’s version of react as an additional copy.

After this change, and refreshing the react-intl node-modules directory, this fixed the original issue.

Cheers,

Marcus