### PR TITLE
Explicitly add uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "mocha": "^2.2.5",
     "react": "^0.14.0-beta3",
     "rimraf": "^2.4.2",
-    "serialize-javascript": "^1.0.0"
+    "serialize-javascript": "^1.0.0",
+    "uglify-js": "^2.4.24"
   },
   "scripts": {
     "clean": "rimraf src/locale-data/ lib/ dist/",


### PR DESCRIPTION
I don't have uglify-js installed globally, so had to add this to get `npm install` to work for the first time.