### PR TITLE
[v2] Refactor imperative API

### DIFF
--- a/examples/translations/src/client/components/locales-menu.js
+++ b/examples/translations/src/client/components/locales-menu.js
@@ -1,28 +1,38 @@
 import React, {Component, PropTypes} from 'react';
-import {intlContextTypes, formatMessage} from 'react-intl';
+import {intlContextTypes, defineMessage} from 'react-intl';
+
+const enUSDescription = defineMessage({
+    id: 'menu.item_en_us_description',
+    defaultMessage: 'The default locale of this example app.',
+});
+
+const enUPPERDescription = defineMessage({
+    id: 'menu.item_en_upper_description',
+    defaultMessage: 'The fake, all uppercase "locale" for this example app.',
+});
 
 class LocalesMenu extends Component {
     render() {
-        const {intl} = this.context;
-
-        let enUSDescription = formatMessage(intl, {
-            id: 'menu.item_en_us_description',
-            defaultMessage: 'The default locale of this example app.',
-        });
-
-        let enUPPERDescription = formatMessage(intl, {
-            id: 'menu.item_en_upper_description',
-            defaultMessage: 'The fake, all uppercase "locale" for this example app.',
-        });
+        const {formatMessage} = this.context.intl;
 
         return (
             <menu>
                 <li>
-                    <a href="/?locale=en-US" title={enUSDescription}>en-US</a>
+                    <a
+                        href="/?locale=en-US"
+                        title={formatMessage(enUSDescription)}
+                    >
+                        en-US
+                    </a>
                 </li>
 
                 <li>
-                    <a href="/?locale=en-UPPER" title={enUPPERDescription}>en-UPPER</a>
+                    <a
+                        href="/?locale=en-UPPER"
+                        title={formatMessage(enUPPERDescription)}
+                    >
+                        en-UPPER
+                    </a>
                 </li>
             </menu>
         );

--- a/src/components/date.js
+++ b/src/components/date.js
@@ -1,18 +1,17 @@
 import {Component, DOM, PropTypes} from 'react';
 import {intlContextTypes, dateTimeFormatPropTypes} from '../types';
-import {formatDate} from '../format';
 import {shouldIntlComponentUpdate} from '../utils';
 
-class FormattedDate extends Component {
+export default class FormattedDate extends Component {
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatDate} = this.context.intl;
+        const props        = this.props;
 
-        let formattedDate = formatDate(intl, props.value, props);
+        let formattedDate = formatDate(props.value, props);
 
         if (typeof props.children === 'function') {
             return props.children(formattedDate);
@@ -30,5 +29,3 @@ FormattedDate.propTypes = Object.assign({}, dateTimeFormatPropTypes, {
 FormattedDate.contextTypes = {
     intl: PropTypes.shape(intlContextTypes).isRequired,
 };
-
-export default FormattedDate;

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -1,6 +1,6 @@
 import {Component, PropTypes, cloneElement, isValidElement} from 'react';
 
-class Group extends Component {
+export default class Group extends Component {
     render() {
         const props = this.props;
 
@@ -22,5 +22,3 @@ class Group extends Component {
 Group.propTypes = {
     children: PropTypes.func.isRequired,
 };
-
-export default Group;

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -1,9 +1,8 @@
 import {Component, PropTypes, createElement} from 'react';
 import {intlContextTypes} from '../types';
-import {formatHTMLMessage} from '../format';
 import {shallowEquals, shouldIntlComponentUpdate} from '../utils';
 
-class FormattedHTMLMessage extends Component {
+export default class FormattedHTMLMessage extends Component {
     shouldComponentUpdate(nextProps, ...next) {
         const values     = this.props.values;
         const nextValues = nextProps.values;
@@ -19,8 +18,8 @@ class FormattedHTMLMessage extends Component {
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatHTMLMessage} = this.context.intl;
+        const props               = this.props;
 
         let {
             id,
@@ -31,7 +30,7 @@ class FormattedHTMLMessage extends Component {
         } = props;
 
         let descriptor           = {id, description, defaultMessage};
-        let formattedHTMLMessage = formatHTMLMessage(intl, descriptor, values);
+        let formattedHTMLMessage = formatHTMLMessage(descriptor, values);
 
         if (typeof props.children === 'function') {
             return props.children(formattedHTMLMessage);
@@ -70,5 +69,3 @@ FormattedHTMLMessage.defaultProps = {
     tagName: 'span',
     values : {},
 };
-
-export default FormattedHTMLMessage;

--- a/src/components/intl.js
+++ b/src/components/intl.js
@@ -4,9 +4,17 @@ import IntlRelativeFormat from 'intl-relativeformat';
 import IntlPluralFormat from '../plural';
 import createFormatCache from 'intl-format-cache';
 import {shouldIntlComponentUpdate} from '../utils';
-import {intlPropTypes, intlContextTypes} from '../types';
+import {intlContextTypes} from '../types';
+import * as format from '../format';
 
-class IntlProvider extends Component {
+function bindFormatFns(intl, localeData) {
+    return Object.keys(intlContextTypes).reduce((types, name) => {
+        types[name] = format[name].bind(null, intl, localeData);
+        return types;
+    }, {});
+}
+
+export default class IntlProvider extends Component {
     constructor(props) {
         super(props);
 
@@ -24,17 +32,11 @@ class IntlProvider extends Component {
     }
 
     getChildContext() {
-        const props = this.props;
+        const intl       = this.state;
+        const localeData = this.props;
 
-        let intl =  Object.assign({
-            locale        : props.locale,
-            formats       : props.formats,
-            messages      : props.messages,
-            defaultLocale : props.defaultLocale,
-            defaultFormats: props.defaultFormats,
-        }, this.state);
-
-        return {intl};
+        // Reduce intl + localeData to just the format functions.
+        return {intl: bindFormatFns(intl, localeData)};
     }
 
     render() {
@@ -52,7 +54,14 @@ class IntlProvider extends Component {
     }
 }
 
-IntlProvider.propTypes = intlPropTypes;
+IntlProvider.propTypes = {
+    locale  : PropTypes.string,
+    formats : PropTypes.object,
+    messages: PropTypes.object,
+
+    defaultLocale : PropTypes.string,
+    defaultFormats: PropTypes.object,
+};
 
 IntlProvider.defaultProps = {
     // TODO: Should `locale` default to 'en'? Or would that cause issues with
@@ -67,5 +76,3 @@ IntlProvider.defaultProps = {
 IntlProvider.childContextTypes = {
     intl: PropTypes.shape(intlContextTypes),
 };
-
-export default IntlProvider;

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -1,9 +1,8 @@
 import {Component, PropTypes, createElement, isValidElement} from 'react';
 import {intlContextTypes} from '../types';
-import {formatMessage} from '../format';
 import {shallowEquals, shouldIntlComponentUpdate} from '../utils';
 
-class FormattedMessage extends Component {
+export default class FormattedMessage extends Component {
     shouldComponentUpdate(nextProps, ...next) {
         const values     = this.props.values;
         const nextValues = nextProps.values;
@@ -19,8 +18,8 @@ class FormattedMessage extends Component {
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatMessage} = this.context.intl;
+        const props           = this.props;
 
         let {
             id,
@@ -30,14 +29,14 @@ class FormattedMessage extends Component {
             tagName,
         } = props;
 
-        // Creates a token with a random guid that should not be guessable or
+        // Creates a token with a random UID that should not be guessable or
         // conflict with other parts of the `message` string.
-        let guid = Math.floor(Math.random() * 0x10000000000).toString(16);
-        let tokenRegexp = new RegExp(`(@__ELEMENT-${guid}-\\d+__@)`, 'g');
+        let uid = Math.floor(Math.random() * 0x10000000000).toString(16);
+        let tokenRegexp = new RegExp(`(@__ELEMENT-${uid}-\\d+__@)`, 'g');
 
         let generateToken = (() => {
             let counter = 0;
-            return () => `@__ELEMENT-${guid}-${counter += 1}__@`;
+            return () => `@__ELEMENT-${uid}-${counter += 1}__@`;
         })();
 
         let tokenizedValues = {};
@@ -61,7 +60,7 @@ class FormattedMessage extends Component {
         });
 
         let descriptor       = {id, description, defaultMessage};
-        let formattedMessage = formatMessage(intl, descriptor, tokenizedValues);
+        let formattedMessage = formatMessage(descriptor, tokenizedValues);
 
         // Split the message into parts so the React Element values captured
         // above can be inserted back into the rendered message. This approach
@@ -97,5 +96,3 @@ FormattedMessage.defaultProps = {
     tagName: 'span',
     values : {},
 };
-
-export default FormattedMessage;

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -1,18 +1,17 @@
 import {Component, DOM, PropTypes} from 'react';
 import {intlContextTypes, numberFormatPropTypes} from '../types';
-import {formatNumber} from '../format';
 import {shouldIntlComponentUpdate} from '../utils';
 
-class FormattedNumber extends Component {
+export default class FormattedNumber extends Component {
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatNumber} = this.context.intl;
+        const props          = this.props;
 
-        let formattedNumber = formatNumber(intl, props.value, props);
+        let formattedNumber = formatNumber(props.value, props);
 
         if (typeof props.children === 'function') {
             return props.children(formattedNumber);
@@ -30,5 +29,3 @@ FormattedNumber.propTypes = Object.assign({}, numberFormatPropTypes, {
 FormattedNumber.contextTypes = {
     intl: PropTypes.shape(intlContextTypes).isRequired,
 };
-
-export default FormattedNumber;

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -1,18 +1,17 @@
 import {Component, DOM, PropTypes} from 'react';
 import {intlContextTypes, pluralFormatPropTypes} from '../types';
-import {formatPlural} from '../format';
 import {shouldIntlComponentUpdate} from '../utils';
 
-class FormattedPlural extends Component {
+export default class FormattedPlural extends Component {
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatPlural} = this.context.intl;
+        const props          = this.props;
 
-        let pluralCategory  = formatPlural(intl, props.value, props);
+        let pluralCategory  = formatPlural(props.value, props);
         let formattedPlural = props[pluralCategory] || props.other;
 
         if (typeof props.children === 'function') {
@@ -33,12 +32,10 @@ FormattedPlural.propTypes = Object.assign({}, pluralFormatPropTypes, {
     many : PropTypes.node,
 });
 
-formatPlural.defaultProps = {
+FormattedPlural.defaultProps = {
     style: 'cardinal',
 };
 
 FormattedPlural.contextTypes = {
     intl: PropTypes.shape(intlContextTypes).isRequired,
 };
-
-export default FormattedPlural;

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -1,18 +1,17 @@
 import {Component, DOM, PropTypes} from 'react';
 import {intlContextTypes, relativeFormatPropTypes} from '../types';
-import {formatRelative} from '../format';
 import {shouldIntlComponentUpdate} from '../utils';
 
-class FormattedRelative extends Component {
+export default class FormattedRelative extends Component {
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatRelative} = this.context.intl;
+        const props            = this.props;
 
-        let formattedRelative = formatRelative(intl, props.value, props);
+        let formattedRelative = formatRelative(props.value, props);
 
         if (typeof props.children === 'function') {
             return props.children(formattedRelative);
@@ -31,5 +30,3 @@ FormattedRelative.propTypes = Object.assign({}, relativeFormatPropTypes, {
 FormattedRelative.contextTypes = {
     intl: PropTypes.shape(intlContextTypes).isRequired,
 };
-
-export default FormattedRelative;

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -1,18 +1,17 @@
 import {Component, DOM, PropTypes} from 'react';
 import {intlContextTypes, dateTimeFormatPropTypes} from '../types';
-import {formatTime} from '../format';
 import {shouldIntlComponentUpdate} from '../utils';
 
-class FormattedTime extends Component {
+export default class FormattedTime extends Component {
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
     render() {
-        const {intl} = this.context;
-        const props  = this.props;
+        const {formatTime} = this.context;
+        const props        = this.props;
 
-        let formattedTime = formatTime(intl, props.value, props);
+        let formattedTime = formatTime(props.value, props);
 
         if (typeof props.children === 'function') {
             return props.children(formattedTime);
@@ -30,5 +29,3 @@ FormattedTime.propTypes = Object.assign({}, dateTimeFormatPropTypes, {
 FormattedTime.contextTypes = {
     intl: PropTypes.shape(intlContextTypes).isRequired,
 };
-
-export default FormattedTime;

--- a/src/format.js
+++ b/src/format.js
@@ -37,73 +37,81 @@ function getNamedFormat(formats, type, name) {
     }
 }
 
-export function formatDate(intl, value, options = {}) {
+export function formatDate(intl, localeData, value, options = {}) {
+    const {locale, formats} = localeData;
+    const {format}          = options;
+
     let date     = new Date(value);
-    let {format} = options;
-    let defaults = format && getNamedFormat(intl.formats, 'date', format);
+    let defaults = format && getNamedFormat(formats, 'date', format);
 
     let filteredOptions = filterFormatOptions(
         DATE_TIME_FORMAT_OPTIONS,
         options, defaults
     );
 
-    return intl.getDateTimeFormat(intl.locale, filteredOptions).format(date);
+    return intl.getDateTimeFormat(locale, filteredOptions).format(date);
 }
 
-export function formatTime(intl, value, options = {}) {
+export function formatTime(intl, localeData, value, options = {}) {
+    const {locale, formats} = localeData;
+    const {format}          = options;
+
     let date     = new Date(value);
-    let {format} = options;
-    let defaults = format && getNamedFormat(intl.formats, 'time', format);
+    let defaults = format && getNamedFormat(formats, 'time', format);
 
     let filteredOptions = filterFormatOptions(
         DATE_TIME_FORMAT_OPTIONS,
         options, defaults
     );
 
-    return intl.getDateTimeFormat(intl.locale, filteredOptions).format(date);
+    return intl.getDateTimeFormat(locale, filteredOptions).format(date);
 }
 
-export function formatRelative(intl, value, options = {}) {
+export function formatRelative(intl, localeData, value, options = {}) {
+    const {locale, formats} = localeData;
+    const {now, format}     = options;
+
     let date     = new Date(value);
-    let {now}    = options;
-    let {format} = options;
-    let defaults = format && getNamedFormat(intl.formats, 'relative', format);
+    let defaults = format && getNamedFormat(formats, 'relative', format);
 
     let filteredOptions = filterFormatOptions(
         RELATIVE_FORMAT_OPTIONS,
         options, defaults
     );
 
-    return intl.getRelativeFormat(intl.locale, filteredOptions).format(date, {now});
+    return intl.getRelativeFormat(locale, filteredOptions).format(date, {now});
 }
 
-export function formatNumber(intl, value, options = {}) {
-    let {format} = options;
-    let defaults = format && getNamedFormat(intl.formats, 'number', format);
+export function formatNumber(intl, localeData, value, options = {}) {
+    const {locale, formats} = localeData;
+    const {format}          = options;
+
+    let defaults = format && getNamedFormat(formats, 'number', format);
 
     let filteredOptions = filterFormatOptions(
         NUMBER_FORMAT_OPTIONS,
         options, defaults
     );
 
-    return intl.getNumberFormat(intl.locale, filteredOptions).format(value);
+    return intl.getNumberFormat(locale, filteredOptions).format(value);
 }
 
-export function formatPlural(intl, value, options = {}) {
+export function formatPlural(intl, localeData, value, options = {}) {
+    const {locale} = localeData;
     let filteredOptions = filterFormatOptions(PLURAL_FORMAT_OPTIONS, options);
-    return intl.getPluralFormat(intl.locale, filteredOptions).format(value);
+    return intl.getPluralFormat(locale, filteredOptions).format(value);
 }
 
-export function formatMessage(intl, messageDescriptor, values = {}) {
-    let {
+export function formatMessage(intl, localeData, messageDescriptor, values = {}) {
+    const {
         locale,
         formats,
         messages,
         defaultLocale,
         defaultFormats,
-    } = intl;
+    } = localeData;
 
-    let {
+    const {
         id,
         defaultMessage,
     } = messageDescriptor;
@@ -173,7 +181,7 @@ export function formatMessage(intl, messageDescriptor, values = {}) {
     return formattedMessage || message || defaultMessage || id;
 }
 
-export function formatHTMLMessage(intl, messageDescriptor, rawValues = {}) {
+export function formatHTMLMessage(intl, localeData, messageDescriptor, rawValues = {}) {
     // Process all the values before they are used when formatting the ICU
     // Message string. Since the formatted message might be injected via
     // `innerHTML`, all String-based values need to be HTML-escaped.
@@ -183,5 +191,5 @@ export function formatHTMLMessage(intl, messageDescriptor, rawValues = {}) {
         return escaped;
     }, {});
 
-    return formatMessage(intl, messageDescriptor, escapedValues);
+    return formatMessage(intl, localeData, messageDescriptor, escapedValues);
 }

--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -12,8 +12,12 @@ export {default as FormattedPlural} from './components/plural';
 export {default as FormattedMessage} from './components/message';
 export {default as FormattedHTMLMessage} from './components/html-message';
 
-export * from './format';
 export {intlContextTypes} from './types';
+
+export function defineMessage(messageDescriptor) {
+    // TODO: Type check in dev? Return something different?
+    return messageDescriptor;
+}
 
 export function addLocaleData(data = []) {
     let locales = Array.isArray(data) ? data : [data];

--- a/src/types.js
+++ b/src/types.js
@@ -1,23 +1,16 @@
 import {PropTypes} from 'react';
 
-const {bool, number, string, object, func, oneOf} = PropTypes;
+const {bool, number, string, func, oneOf} = PropTypes;
 
-export const intlPropTypes = {
-    locale  : string,
-    formats : object,
-    messages: object,
-
-    defaultLocale : string,
-    defaultFormats: object,
+export const intlContextTypes = {
+    formatDate       : func.isRequired,
+    formatTime       : func.isRequired,
+    formatRelative   : func.isRequired,
+    formatNumber     : func.isRequired,
+    formatPlural     : func.isRequired,
+    formatMessage    : func.isRequired,
+    formatHTMLMessage: func.isRequired,
 };
-
-export const intlContextTypes = Object.assign({}, intlPropTypes, {
-    getDateTimeFormat: func.isRequired,
-    getNumberFormat  : func.isRequired,
-    getMessageFormat : func.isRequired,
-    getRelativeFormat: func.isRequired,
-    getPluralFormat  : func.isRequired,
-});
 
 export const dateTimeFormatPropTypes = {
     localeMatcher: oneOf(['best fit', 'lookup']),


### PR DESCRIPTION
This reduces React Intl's API surface and simplifies the imperative API.

There is now a `defineMessage()` export which serves as the hook for the static analysis message extraction via babel-plugin-react-intl.

The `this.context.intl` object now contains the format functions.

These changes make the imperative API less complex as well as more flexible for defining messages and using them more than once.

/cc @caridy @redonkulus @mridgway