### PR TITLE
[v2] Fix `defaultMessage` in example

### DIFF
--- a/examples/translations/src/client/components/greeting.js
+++ b/examples/translations/src/client/components/greeting.js
@@ -12,7 +12,7 @@ class Greeting extends Component {
                     defaultMessage={`
                         Welcome {name}, you have received {unreadCount, plural,
                             =0 {no new messages}
-                            one {{formattedUnreadCount} new messages}
+                            one {{formattedUnreadCount} new message}
                             other {{formattedUnreadCount} new messages}
                         } since {formattedLastLoginTime}.
                     `}


### PR DESCRIPTION
Minor detail, but can be confusing to someone learning the message syntax from the example.