### PR TITLE
Add injectIntl() HOC

### DIFF
--- a/examples/translations/src/client/components/locales-menu.js
+++ b/examples/translations/src/client/components/locales-menu.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {intlShape, defineMessages} from 'react-intl';
+import {intlShape, injectIntl, defineMessages} from 'react-intl';
 
 const messages = defineMessages({
     enUSDescription: {
@@ -14,7 +14,7 @@ const messages = defineMessages({
 
 class LocalesMenu extends Component {
     render() {
-        const {formatMessage} = this.context.intl;
+        const {formatMessage} = this.props.intl;
 
         return (
             <menu>
@@ -40,8 +40,8 @@ class LocalesMenu extends Component {
     }
 }
 
-LocalesMenu.contextTypes = {
+LocalesMenu.propTypes = {
     intl: intlShape.isRequired,
 };
 
-export default LocalesMenu;
+export default injectIntl(LocalesMenu);

--- a/src/components/date.js
+++ b/src/components/date.js
@@ -6,9 +6,14 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {shouldIntlComponentUpdate} from '../utils';
+import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedDate extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
@@ -34,5 +39,5 @@ FormattedDate.propTypes = {
 };
 
 FormattedDate.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -6,9 +6,18 @@
 
 import {Component, PropTypes, createElement} from 'react';
 import {intlShape} from '../types';
-import {shallowEquals, shouldIntlComponentUpdate} from '../utils';
+import {
+    assertIntlContext,
+    shallowEquals,
+    shouldIntlComponentUpdate,
+} from '../utils';
 
 export default class FormattedHTMLMessage extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(nextProps, ...next) {
         const values     = this.props.values;
         const nextValues = nextProps.values;
@@ -70,7 +79,7 @@ FormattedHTMLMessage.propTypes = {
 };
 
 FormattedHTMLMessage.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };
 
 FormattedHTMLMessage.defaultProps = {

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -6,9 +6,18 @@
 
 import {Component, PropTypes, createElement, isValidElement} from 'react';
 import {intlShape} from '../types';
-import {shallowEquals, shouldIntlComponentUpdate} from '../utils';
+import {
+    assertIntlContext,
+    shallowEquals,
+    shouldIntlComponentUpdate,
+} from '../utils';
 
 export default class FormattedMessage extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(nextProps, ...next) {
         const values     = this.props.values;
         const nextValues = nextProps.values;
@@ -97,7 +106,7 @@ FormattedMessage.propTypes = {
 };
 
 FormattedMessage.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };
 
 FormattedMessage.defaultProps = {

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -6,9 +6,14 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, numberFormatPropTypes} from '../types';
-import {shouldIntlComponentUpdate} from '../utils';
+import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedNumber extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
@@ -34,5 +39,5 @@ FormattedNumber.propTypes = {
 };
 
 FormattedNumber.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -6,9 +6,14 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, pluralFormatPropTypes} from '../types';
-import {shouldIntlComponentUpdate} from '../utils';
+import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedPlural extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
@@ -48,5 +53,5 @@ FormattedPlural.defaultProps = {
 };
 
 FormattedPlural.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -6,9 +6,14 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, relativeFormatPropTypes} from '../types';
-import {shouldIntlComponentUpdate} from '../utils';
+import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedRelative extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
@@ -35,5 +40,5 @@ FormattedRelative.propTypes = {
 };
 
 FormattedRelative.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -6,9 +6,14 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {shouldIntlComponentUpdate} from '../utils';
+import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedTime extends Component {
+    constructor(props, context) {
+        super(props, context);
+        assertIntlContext(context);
+    }
+
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
@@ -34,5 +39,5 @@ FormattedTime.propTypes = {
 };
 
 FormattedTime.contextTypes = {
-    intl: intlShape.isRequired,
+    intl: intlShape,
 };

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+import React, {Component} from 'react';
+import {intlShape} from './types';
+import {assertIntlContext} from './utils';
+
+function getDisplayName(Component) {
+    return Component.displayName || Component.name || 'Component';
+}
+
+export default function injectIntl(WrappedComponent, options = {}) {
+    const {intlPropName = 'intl'} = options;
+
+    class InjectIntl extends Component {
+        constructor(props, context) {
+            super(props, context);
+            assertIntlContext(context);
+        }
+
+        render() {
+            return (
+                <WrappedComponent
+                    {...this.props}
+                    {...{[intlPropName]: this.context.intl}}
+                    ref='wrappedElement'
+                />
+            );
+        }
+    }
+
+    InjectIntl.displayName = `IntjectIntl(${getDisplayName(WrappedComponent)})`;
+
+    InjectIntl.contextTypes = {
+        intl: intlShape,
+    };
+
+    return InjectIntl;
+}

--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -17,6 +17,7 @@ export {default as FormattedNumber} from './components/number';
 export {default as FormattedPlural} from './components/plural';
 export {default as FormattedMessage} from './components/message';
 export {default as FormattedHTMLMessage} from './components/html-message';
+export {default as injectIntl} from './inject';
 
 export {intlShape} from './types';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,6 +51,17 @@ export function shallowEquals(objA, objB) {
     return true;
 }
 
+export function assertIntlContext({intl} = {}) {
+    if (process.env.NODE_ENV !== 'production') {
+        if (!intl) {
+            console.error(
+                '[React Intl] Could not find required `intl` object. ' +
+                '`IntlProvider` needs to exist in the component ancestry.'
+            );
+        }
+    }
+}
+
 export function shouldIntlComponentUpdate(instance, nextProps, nextState, nextContext = {}) {
     const context  = instance.context || {};
     const intl     = context.intl || {};

--- a/test/unit/react-intl-with-locales.js
+++ b/test/unit/react-intl-with-locales.js
@@ -11,6 +11,10 @@ describe('react-intl-with-locales', () => {
             expect(ReactIntl.defineMessages).toBeA('function');
         });
 
+        it('exports `injectIntl`', () => {
+            expect(ReactIntl.defineMessages).toBeA('function');
+        });
+
         describe('React Components', () => {
             it('exports `IntlProvider`', () => {
                 expect(ReactIntl.IntlProvider).toBeA('function');

--- a/test/unit/react-intl.js
+++ b/test/unit/react-intl.js
@@ -11,6 +11,10 @@ describe('react-intl', () => {
             expect(ReactIntl.defineMessages).toBeA('function');
         });
 
+        it('exports `injectIntl`', () => {
+            expect(ReactIntl.defineMessages).toBeA('function');
+        });
+
         describe('React Components', () => {
             it('exports `IntlProvider`', () => {
                 expect(ReactIntl.IntlProvider).toBeA('function');


### PR DESCRIPTION
This will inject the `intl` context object created by the `<IntlProvider>` as a prop on the wrapped component. Using the HOC factory function allivates the need for `context` to be a part of the
public API.