### PR TITLE
Update dist/locale-data/ to be UMD files

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,13 +57,14 @@
     "react-addons-test-utils": "^0.14.0-beta3",
     "rimraf": "^2.4.2",
     "serialize-javascript": "^1.1.1",
-    "uglify-js": "^2.4.24"
+    "uglify-js": "^2.4.24",
+    "uglifyify": "^3.0.1"
   },
   "scripts": {
     "lint": "eslint src/ test/ scripts/ examples/",
     "clean": "rimraf src/en.js src/locale-data/ lib/ dist/",
     "build:data": "babel-node scripts/build-locale-data.js",
-    "build:lib": "babel src/ --out-dir lib/",
+    "build:lib": "babel src/ --ignore src/locale-data/ --out-dir lib/",
     "build:dist:main": "browserify src/react-intl.js -s ReactIntl -g [envify --NODE_ENV development] -t babelify -t browserify-shim -d | exorcist -b ./ -r react-intl:/// dist/react-intl.js.map > dist/react-intl.js",
     "build:dist:main:min": "browserify src/react-intl.js -s ReactIntl -g [envify --NODE_ENV production] -t babelify -t browserify-shim | uglifyjs -c -m > dist/react-intl.min.js",
     "build:dist:with-data": "browserify src/react-intl-with-locales.js -s ReactIntl -g [envify --NODE_ENV development] -t babelify -t browserify-shim -d | exorcist -b ./ -r react-intl:/// dist/react-intl-with-locales.js.map > dist/react-intl-with-locales.js",

--- a/scripts/build-locale-data.js
+++ b/scripts/build-locale-data.js
@@ -2,6 +2,9 @@ import * as fs from 'fs';
 import {sync as mkdirpSync} from 'mkdirp';
 import extractCLDRData from 'formatjs-extract-cldr-data';
 import serialize from 'serialize-javascript';
+import {transform} from 'babel';
+import browserify from 'browserify';
+import uglifyify from 'uglifyify';
 
 const DEFAULT_LOCALE = 'en';
 
@@ -10,11 +13,11 @@ const cldrData = extractCLDRData({
     relativeFields: true,
 });
 
-const dataByLocale = new Map(
+const cldrDataByLocale = new Map(
     Object.keys(cldrData).map((locale) => [locale, cldrData[locale]])
 );
 
-const dataByLang = [...dataByLocale].reduce((map, [locale, data]) => {
+const cldrDataByLang = [...cldrDataByLocale].reduce((map, [locale, data]) => {
     let [lang]   = locale.split('-');
     let langData = map.get(lang) || [];
     return map.set(lang, langData.concat(data));
@@ -28,28 +31,39 @@ export default ${serialize(localeData)};
     );
 }
 
-function createDistDataScript(localeData) {
-    return (
-`// GENERATED FILE
-ReactIntl.addLocaleData(${serialize(localeData)});
-`
-    );
+function throwIfError(error) {
+    if (error) {
+        throw error;
+    }
 }
 
 // -----------------------------------------------------------------------------
 
-mkdirpSync('src/locale-data/');
 mkdirpSync('dist/locale-data/');
+mkdirpSync('lib/locale-data/');
+mkdirpSync('src/locale-data/');
 
-fs.writeFileSync('src/en.js',
-    createDataModule(dataByLocale.get(DEFAULT_LOCALE))
+fs.writeFile('src/en.js',
+    createDataModule(cldrDataByLocale.get(DEFAULT_LOCALE)),
+    throwIfError
 );
 
-fs.writeFileSync('src/locale-data/index.js',
-    createDataModule([...dataByLocale.values()])
-);
+let allData = createDataModule([...cldrDataByLocale.values()]);
+fs.writeFile('src/locale-data/index.js', allData, throwIfError);
+fs.writeFile('lib/locale-data/index.js', transform(allData).code, throwIfError);
 
-dataByLang.forEach((data, lang) => {
-    fs.writeFileSync(`src/locale-data/${lang}.js`, createDataModule(data));
-    fs.writeFileSync(`dist/locale-data/${lang}.js`, createDistDataScript(data));
+cldrDataByLang.forEach((cldrData, lang) => {
+    let data = createDataModule(cldrData);
+
+    fs.writeFile(`src/locale-data/${lang}.js`, data, throwIfError);
+    fs.writeFile(`lib/locale-data/${lang}.js`, transform(data).code, (err) => {
+        throwIfError(err);
+
+        browserify({standalone: `ReactIntlLocaleData.${lang}`})
+            .add(`lib/locale-data/${lang}.js`)
+            .transform(uglifyify)
+            .bundle()
+            .on('error', throwIfError)
+            .pipe(fs.createWriteStream(`dist/locale-data/${lang}.js`));
+    });
 });


### PR DESCRIPTION
This keeps with the theme of v2 where locale data is provided as modules, instead of causing side-effects to the ReactIntl library.

With the change, the locale data files in `dist/` will expose the data at: `ReactIntlLocaleData.<lang>`. This decouples the loading of the locale data files from the loading of the library.