### PR TITLE
Replace defineMessage() with defineMessages()

### DIFF
--- a/examples/translations/src/client/components/locales-menu.js
+++ b/examples/translations/src/client/components/locales-menu.js
@@ -1,14 +1,15 @@
 import React, {Component} from 'react';
-import {intlShape, defineMessage} from 'react-intl';
+import {intlShape, defineMessages} from 'react-intl';
 
-const enUSDescription = defineMessage({
-    id: 'menu.item_en_us_description',
-    defaultMessage: 'The default locale of this example app.',
-});
-
-const enUPPERDescription = defineMessage({
-    id: 'menu.item_en_upper_description',
-    defaultMessage: 'The fake, all uppercase "locale" for this example app.',
+const messages = defineMessages({
+    enUSDescription: {
+        id: 'menu.item_en_us_description',
+        defaultMessage: 'The default locale of this example app.',
+    },
+    enUPPERDescription: {
+        id: 'menu.item_en_upper_description',
+        defaultMessage: 'The fake, all uppercase "locale" for this example app.',
+    },
 });
 
 class LocalesMenu extends Component {
@@ -20,7 +21,7 @@ class LocalesMenu extends Component {
                 <li>
                     <a
                         href="/?locale=en-US"
-                        title={formatMessage(enUSDescription)}
+                        title={formatMessage(messages.enUSDescription)}
                     >
                         en-US
                     </a>
@@ -29,7 +30,7 @@ class LocalesMenu extends Component {
                 <li>
                     <a
                         href="/?locale=en-UPPER"
-                        title={formatMessage(enUPPERDescription)}
+                        title={formatMessage(messages.enUPPERDescription)}
                     >
                         en-UPPER
                     </a>

--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -20,12 +20,6 @@ export {default as FormattedHTMLMessage} from './components/html-message';
 
 export {intlShape} from './types';
 
-// TODO: Can we get rid of this nad only go with the multiple version?
-export function defineMessage(messageDescriptor) {
-    // TODO: Type check in dev? Return something different?
-    return messageDescriptor;
-}
-
 export function defineMessages(messageDescriptors) {
     // TODO: Type check in dev? Return something different?
     return messageDescriptors;

--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -20,10 +20,15 @@ export {default as FormattedHTMLMessage} from './components/html-message';
 
 export {intlShape} from './types';
 
-// TODO Should there be a `defineMessages()` function that takes a collection?
+// TODO: Can we get rid of this nad only go with the multiple version?
 export function defineMessage(messageDescriptor) {
     // TODO: Type check in dev? Return something different?
     return messageDescriptor;
+}
+
+export function defineMessages(messageDescriptors) {
+    // TODO: Type check in dev? Return something different?
+    return messageDescriptors;
 }
 
 export function addLocaleData(data = []) {

--- a/test/unit/react-intl-with-locales.js
+++ b/test/unit/react-intl-with-locales.js
@@ -11,6 +11,10 @@ describe('react-intl-with-locales', () => {
             expect(ReactIntl.defineMessage).toBeA('function');
         });
 
+        it('exports `defineMessages`', () => {
+            expect(ReactIntl.defineMessages).toBeA('function');
+        });
+
         describe('React Components', () => {
             it('exports `IntlProvider`', () => {
                 expect(ReactIntl.IntlProvider).toBeA('function');

--- a/test/unit/react-intl-with-locales.js
+++ b/test/unit/react-intl-with-locales.js
@@ -7,10 +7,6 @@ describe('react-intl-with-locales', () => {
             expect(ReactIntl.addLocaleData).toBeA('function');
         });
 
-        it('exports `defineMessage`', () => {
-            expect(ReactIntl.defineMessage).toBeA('function');
-        });
-
         it('exports `defineMessages`', () => {
             expect(ReactIntl.defineMessages).toBeA('function');
         });

--- a/test/unit/react-intl.js
+++ b/test/unit/react-intl.js
@@ -11,6 +11,10 @@ describe('react-intl', () => {
             expect(ReactIntl.defineMessage).toBeA('function');
         });
 
+        it('exports `defineMessages`', () => {
+            expect(ReactIntl.defineMessages).toBeA('function');
+        });
+
         describe('React Components', () => {
             it('exports `IntlProvider`', () => {
                 expect(ReactIntl.IntlProvider).toBeA('function');

--- a/test/unit/react-intl.js
+++ b/test/unit/react-intl.js
@@ -7,10 +7,6 @@ describe('react-intl', () => {
             expect(ReactIntl.addLocaleData).toBeA('function');
         });
 
-        it('exports `defineMessage`', () => {
-            expect(ReactIntl.defineMessage).toBeA('function');
-        });
-
         it('exports `defineMessages`', () => {
             expect(ReactIntl.defineMessages).toBeA('function');
         });


### PR DESCRIPTION
This is a new function that allow multiple messages to be defined (and extracted by the Babel plugin.) The bigger question is whether the singular form `defineMessage()` should be removed in favor of just having this one.