### PR TITLE
Update jsDOM to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "expect": "^1.9.0",
     "formatjs-extract-cldr-data": "^1.1.1",
     "intl": "^1.0.0",
-    "jsdom": "^3.1.2",
+    "jsdom": "^6.5.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",


### PR DESCRIPTION
The jsDOM being included was 3 major versions back from the lates and was causing build failures in node 4.1 and 0.10. Updating the version corrects the issue.

Closes https://github.com/yahoo/react-intl/issues/177