### PR TITLE
Fallback when locale data is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class App extends Component {
 }
 
 ReactDOM.render(
-    <IntlProvider>
+    <IntlProvider locale="en">
         <App />
     </IntlProvider>,
     document.getElementById('container')

--- a/examples/hello-world/index.js
+++ b/examples/hello-world/index.js
@@ -28,7 +28,7 @@ class App extends Component {
 }
 
 ReactDOM.render(
-    <IntlProvider>
+    <IntlProvider locale="en">
         <App />
     </IntlProvider>,
     document.getElementById('container')

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "intl-format-cache": "2.0.4",
     "intl-messageformat": "1.1.0",
-    "intl-relativeformat": "1.1.0"
+    "intl-relativeformat": "1.1.0",
+    "invariant": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^0.14.0"

--- a/src/components/date.js
+++ b/src/components/date.js
@@ -6,12 +6,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedDate extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(...next) {

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -7,7 +7,7 @@
 import {Component, PropTypes, createElement} from 'react';
 import {intlShape} from '../types';
 import {
-    assertIntlContext,
+    invariantIntlContext,
     shallowEquals,
     shouldIntlComponentUpdate,
 } from '../utils';
@@ -15,7 +15,7 @@ import {
 export default class FormattedHTMLMessage extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(nextProps, ...next) {

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -7,7 +7,7 @@
 import {Component, PropTypes, createElement, isValidElement} from 'react';
 import {intlShape} from '../types';
 import {
-    assertIntlContext,
+    invariantIntlContext,
     shallowEquals,
     shouldIntlComponentUpdate,
 } from '../utils';
@@ -15,7 +15,7 @@ import {
 export default class FormattedMessage extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(nextProps, ...next) {

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -6,12 +6,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, numberFormatPropTypes} from '../types';
-import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedNumber extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(...next) {

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -6,12 +6,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, pluralFormatPropTypes} from '../types';
-import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedPlural extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(...next) {

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -6,12 +6,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, relativeFormatPropTypes} from '../types';
-import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedRelative extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(...next) {

--- a/src/components/time.js
+++ b/src/components/time.js
@@ -6,12 +6,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, dateTimeFormatPropTypes} from '../types';
-import {assertIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
 
 export default class FormattedTime extends Component {
     constructor(props, context) {
         super(props, context);
-        assertIntlContext(context);
+        invariantIntlContext(context);
     }
 
     shouldComponentUpdate(...next) {

--- a/src/format.js
+++ b/src/format.js
@@ -4,6 +4,8 @@
  * See the accompanying LICENSE file for terms.
  */
 
+import invariant from 'invariant';
+
 import {
     dateTimeFormatPropTypes,
     numberFormatPropTypes,
@@ -122,8 +124,7 @@ export function formatMessage(intl, config, messageDescriptor, values = {}) {
         defaultMessage,
     } = messageDescriptor;
 
-    // TODO: What should we do when the message descriptor doesn't have an `id`?
-    // Should we return some placeholder value, not care, or throw?
+    invariant(id, '[React Intl] An `id` must be provided to format a message.');
 
     let message = messages && messages[id];
 
@@ -182,8 +183,6 @@ export function formatMessage(intl, config, messageDescriptor, values = {}) {
         }
     }
 
-    // TODO: Should the string first be trimmed? This will support strings
-    // defined using template literals. <pre> rendering would be the counter.
     return formattedMessage || message || defaultMessage || id;
 }
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -6,7 +6,7 @@
 
 import React, {Component} from 'react';
 import {intlShape} from './types';
-import {assertIntlContext} from './utils';
+import {invariantIntlContext} from './utils';
 
 function getDisplayName(Component) {
     return Component.displayName || Component.name || 'Component';
@@ -18,7 +18,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
     class InjectIntl extends Component {
         constructor(props, context) {
             super(props, context);
-            assertIntlContext(context);
+            invariantIntlContext(context);
         }
 
         render() {

--- a/src/locale-data-registry.js
+++ b/src/locale-data-registry.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+import {__addLocaleData as addIMFLocaleData} from 'intl-messageformat';
+import {__addLocaleData as addIRFLocaleData} from 'intl-relativeformat';
+
+const registeredLocales = Object.create(null);
+
+export function addLocaleData(data = []) {
+    let locales = Array.isArray(data) ? data : [data];
+
+    locales.forEach((localeData) => {
+        addIMFLocaleData(localeData);
+        addIRFLocaleData(localeData);
+
+        let {locale} = localeData;
+        registeredLocales[locale.toLowerCase()] = locale;
+    });
+}
+
+export function hasLocaleData(locale) {
+    return !!registeredLocales[locale.toLowerCase()];
+}

--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -4,9 +4,14 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import {__addLocaleData as addIMFLocaleData} from 'intl-messageformat';
-import {__addLocaleData as addIRFLocaleData} from 'intl-relativeformat';
 import defaultLocaleData from './en';
+import {addLocaleData} from './locale-data-registry';
+
+addLocaleData(defaultLocaleData);
+
+export {addLocaleData};
+export {intlShape} from './types';
+export {default as injectIntl} from './inject';
 
 export {default as IntlProvider} from './components/intl';
 export {default as FormattedDate} from './components/date';
@@ -16,22 +21,9 @@ export {default as FormattedNumber} from './components/number';
 export {default as FormattedPlural} from './components/plural';
 export {default as FormattedMessage} from './components/message';
 export {default as FormattedHTMLMessage} from './components/html-message';
-export {default as injectIntl} from './inject';
-
-export {intlShape} from './types';
 
 export function defineMessages(messageDescriptors) {
-    // TODO: Type check in dev? Return something different?
+    // This simply returns what's passed-in because it's meant to be a hook for
+    // babel-plugin-react-intl.
     return messageDescriptors;
 }
-
-export function addLocaleData(data = []) {
-    let locales = Array.isArray(data) ? data : [data];
-
-    locales.forEach((localeData) => {
-        addIMFLocaleData(localeData);
-        addIRFLocaleData(localeData);
-    });
-}
-
-addLocaleData(defaultLocaleData);

--- a/src/types.js
+++ b/src/types.js
@@ -9,7 +9,7 @@ import {PropTypes} from 'react';
 const {bool, number, string, func, object, oneOf, shape} = PropTypes;
 
 export const intlPropTypes = {
-    locale  : string,
+    locale  : string.isRequired,
     formats : object,
     messages: object,
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,8 @@ This source code is licensed under the BSD-style license found in the LICENSE
 file in the root directory of React's source tree.
 */
 
+import invariant from 'invariant';
+
 const ESCAPED_CHARS = {
     '&' : '&amp;',
     '>' : '&gt;',
@@ -21,6 +23,14 @@ const UNSAFE_CHARS_REGEX = /[&><"']/g;
 
 export function escape(str) {
     return ('' + str).replace(UNSAFE_CHARS_REGEX, (match) => ESCAPED_CHARS[match]);
+}
+
+export function invariantIntlContext({intl} = {}) {
+    invariant(
+        intl,
+        '[React Intl] Could not find required `intl` object. ' +
+        '<IntlProvider> needs to exist in the component ancestry.'
+    );
 }
 
 export function shallowEquals(objA, objB) {
@@ -49,17 +59,6 @@ export function shallowEquals(objA, objB) {
     }
 
     return true;
-}
-
-export function assertIntlContext({intl} = {}) {
-    if (process.env.NODE_ENV !== 'production') {
-        if (!intl) {
-            console.error(
-                '[React Intl] Could not find required `intl` object. ' +
-                '`IntlProvider` needs to exist in the component ancestry.'
-            );
-        }
-    }
 }
 
 export function shouldIntlComponentUpdate(instance, nextProps, nextState, nextContext = {}) {


### PR DESCRIPTION
A common problem people are facing is having some parts of the app, namely the ones that use `<FormattedDate>`, `<FormattedNumber>`, and `<FormattedTime>` rendering properly in the `locale` they set. While other components like `<FormattedMessage>`, `<FormattedPlural>`, and `<FormattedRelative>` render in English. This is happening because the locale data hasn't been loaded and registered with React Intl.

These changes will warn when this situation is encountered and fallback to rendering everything in the default locale: English.

Fixes #173
Fixes #184