### PR TITLE
Stabilize "now" time and "tick" relative times

### DIFF
--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -8,21 +8,112 @@ import React, {Component, PropTypes} from 'react';
 import {intlShape, relativeFormatPropTypes} from '../types';
 import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
 
+const SECOND = 1000;
+const MINUTE = 1000 * 60;
+const HOUR   = 1000 * 60 * 60;
+const DAY    = 1000 * 60 * 60 * 24;
+
+// The maximum timer delay value is a 32-bit signed integer.
+// See: https://mdn.io/setTimeout
+const MAX_TIMER_DELAY = 2147483647;
+
+function selectUnits(delta) {
+    let absDelta = Math.abs(delta);
+
+    if (absDelta < MINUTE) {
+        return 'second';
+    }
+
+    if (absDelta < HOUR) {
+        return 'minute';
+    }
+
+    if (absDelta < DAY) {
+        return 'hour';
+    }
+
+    // The maximum scheduled delay will be measured in days since the maximum
+    // timer delay is less than the number of milliseconds in 25 days.
+    return 'day';
+}
+
+function getUnitDelay(units) {
+    switch (units) {
+    case 'second': return SECOND;
+    case 'minute': return MINUTE;
+    case 'hour'  : return HOUR;
+    case 'day'   : return DAY;
+    default      : return MAX_TIMER_DELAY;
+    }
+}
+
 export default class FormattedRelative extends Component {
     constructor(props, context) {
         super(props, context);
         invariantIntlContext(context);
+
+        let now = isFinite(props.initialNow) ?
+                Number(props.initialNow) : context.intl.now();
+
+        // `now` is stored as state so that `render()` remains a function of
+        // props + state, instead of accessing `Date.now()` inside `render()`.
+        this.state = {now};
+    }
+
+    scheduleNextUpdate(props, state) {
+        const {updateInterval} = props;
+
+        // If the `updateInterval` is falsy, including `0`, then auto updates
+        // have been turned off, so we bail and skip scheduling an update.
+        if (!updateInterval) {
+            return;
+        }
+
+        let delta = Number(props.value) - state.now;
+        let units = props.units || selectUnits(delta);
+
+        let unitDelay     = getUnitDelay(units);
+        let unitRemainder = Math.abs(delta % unitDelay);
+
+        // We want the largest possible timer delay which will still display
+        // accurate information while reducing unnecessary re-renders. The delay
+        // should be until the next "interesting" moment, like a tick from
+        // "1 minute ago" to "2 minutes ago" when the delta is 120,000ms.
+        let delay = delta < 0 ?
+            Math.max(updateInterval, unitDelay - unitRemainder) :
+            Math.max(updateInterval, unitRemainder);
+
+        clearTimeout(this._timer);
+
+        this._timer = setTimeout(() => {
+            this.setState({now: this.context.intl.now()});
+        }, delay);
     }
 
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
+    componentWillUpdate(nextProps, nextState) {
+        this.scheduleNextUpdate(nextProps, nextState);
+    }
+
+    componentDidMount() {
+        this.scheduleNextUpdate(this.props, this.state);
+    }
+
+    componentWillUnmount() {
+        clearTimeout(this._timer);
+    }
+
     render() {
         const {formatRelative} = this.context.intl;
-        const props            = this.props;
+        const {props, state}   = this;
 
-        let formattedRelative = formatRelative(props.value, props);
+        let formattedRelative = formatRelative(props.value, {
+            ...props,
+            ...state,
+        });
 
         if (typeof props.children === 'function') {
             return props.children(formattedRelative);
@@ -40,7 +131,12 @@ FormattedRelative.contextTypes = {
 
 FormattedRelative.propTypes = {
     ...relativeFormatPropTypes,
-    format: PropTypes.string,
-    value : PropTypes.any.isRequired,
-    now   : PropTypes.any,
+    value         : PropTypes.any.isRequired,
+    format        : PropTypes.string,
+    initialNow    : PropTypes.any,
+    updateInterval: PropTypes.number,
+};
+
+FormattedRelative.defaultProps = {
+    updateInterval: 1000 * 10,
 };

--- a/src/format.js
+++ b/src/format.js
@@ -87,7 +87,9 @@ export function formatRelative(config, state, value, options = {}) {
         options, defaults
     );
 
-    return state.getRelativeFormat(locale, filteredOptions).format(date, {now});
+    return state.getRelativeFormat(locale, filteredOptions).format(date, {
+        now: isFinite(now) ? now : state.now(),
+    });
 }
 
 export function formatNumber(config, state, value, options = {}) {

--- a/src/types.js
+++ b/src/types.js
@@ -30,6 +30,7 @@ export const intlFormatPropTypes = {
 export const intlShape = shape({
     ...intlPropTypes,
     ...intlFormatPropTypes,
+    now: func.isRequired,
 });
 
 export const dateTimeFormatPropTypes = {


### PR DESCRIPTION
This adds a new `initialNow` prop to `<IntlProvider>` to stabilize the reference time when formatting relative times during the initial render. This prop should be set when rendering a universal React app
on the server and client so the initial client render will match the server's checksum.

On the server, `Date.now()` should be captured before calling `ReactDOM.renderToString()` and provided to `<IntlProvider>`. This "now" value needs to be serialized to the client so it can also pass the same value to `<IntlProvider>` when it calls `React.render()`.

Relatives times formatted via `<FormattedRelative>` will now "tick" and stay up to date over time. The `<FormattedRelative>` component's `now` prop has been renamed, `initialNow` to match and override the same prop on `<IntlProvider>`. It also has a new `updateInterval` prop which accepts a number of milliseconds for the maximum speed at which relative times should be updated (defaults to 10 seconds).

Special care has been taken in the scheduling algorithm to display accurate information while reducing unnecessary re-renders. The algorithm will update the relative time at its next "interesting" moment; e.g., "1 minute ago" to "2 minutes ago" will use a delay of 60 seconds even if `updateInterval` is set to 1 second.

Fixes #186