### PR TITLE
Improve support for nested <IntlProvider>s

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
+    "clean": "../../node_modules/.bin/rimraf build",
     "build": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify index.js -d -t babelify -t browserify-shim > build/bundle.js",
     "start": "../../node_modules/.bin/babel-node server.js"
   },

--- a/examples/nested/.babelrc
+++ b/examples/nested/.babelrc
@@ -1,0 +1,8 @@
+{
+    "plugins": ["react-intl"],
+    "extra": {
+        "react-intl": {
+            "messagesDir": "./build/messages/"
+        }
+    }
+}

--- a/examples/nested/.gitignore
+++ b/examples/nested/.gitignore
@@ -1,0 +1,2 @@
+build/
+!lib/

--- a/examples/nested/README.md
+++ b/examples/nested/README.md
@@ -1,0 +1,23 @@
+React Intl Nested Example
+=========================
+
+This is a runnable example showing how to use React Intl with nested collections of string messages from different "widgets" that could be defined in separate npm packages and combined in one app.
+
+This example app creates a string messages bundle per logical widget in the app via the `scripts/group-messages.js` script.
+
+## Running
+
+**You first need to build the main React Intl library:**
+
+```
+$ cd ../..
+$ npm run build
+$ cd examples/nested/
+```
+
+Then you can build and run this example:
+
+```
+$ npm run build
+$ npm start
+```

--- a/examples/nested/package.json
+++ b/examples/nested/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "react-intl-example-nested",
+  "version": "1.0.0",
+  "description": "React Intl Nested Widgets Example",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "clean": "../../node_modules/.bin/rimraf build",
+    "build:bundle": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify src/client/index.js -d -t babelify -t browserify-shim > build/bundle.js",
+    "build:group-messages": "../../node_modules/.bin/babel-node scripts/group-messages.js",
+    "build": "npm run build:bundle && npm run build:group-messages",
+    "start": "../../node_modules/.bin/babel-node src/server/index.js"
+  },
+  "author": "Eric Ferraiuolo <edf@ericf.me>",
+  "license": "BSD-3-Clause",
+  "browser": {
+    "react-intl": "../../lib/react-intl.js",
+    "react-intl/locale-data/en": "../../lib/locale-data/en.js"
+  },
+  "browserify-shim": {
+    "react": "global:React",
+    "react-dom": "global:ReactDOM"
+  }
+}

--- a/examples/nested/scripts/group-messages.js
+++ b/examples/nested/scripts/group-messages.js
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as p from 'path';
+import {sync as globSync} from 'glob';
+import {sync as mkdirpSync} from 'mkdirp';
+
+const MESSAGES_PATTERN = './build/messages/**/*.json';
+const LANG_DIR         = './build/lang/';
+
+// Groups the default messages by namespace that were extracted from the example
+// app's React components via the React Intl Babel plugin. An error will be
+// thrown if there are messages in the same namespace use the same `id`. The
+// result is a collection of namespaced collections of `id: message` pairs for
+// the app's default locale, "en-US".
+let namespacedMessages = globSync(MESSAGES_PATTERN)
+    .map((filename) => fs.readFileSync(filename, 'utf8'))
+    .map((file) => JSON.parse(file))
+    .reduce((collections, descriptors) => {
+        descriptors.forEach(({id, defaultMessage}) => {
+            let namespace  = id.split('.')[0];
+            let collection = collections[namespace];
+
+            if (!collection) {
+                collection = collections[namespace] = {};
+            }
+
+            if (collection.hasOwnProperty(id)) {
+                throw new Error(`Duplicate message id: ${id}`);
+            }
+
+            collection[id] = defaultMessage;
+        });
+
+        return collections;
+    }, {});
+
+Object.keys(namespacedMessages).forEach((namespace) => {
+    let collection = namespacedMessages[namespace];
+    let filename   = p.join(LANG_DIR, namespace, 'en-US.json');
+
+    mkdirpSync(p.dirname(filename));
+    fs.writeFileSync(filename, JSON.stringify(collection, null, 2));
+});

--- a/examples/nested/src/client/components/app.js
+++ b/examples/nested/src/client/components/app.js
@@ -1,0 +1,42 @@
+import React, {Component, PropTypes} from 'react';
+import {IntlProvider, FormattedMessage} from 'react-intl';
+import Greeting from './widgets/greeting';
+
+class App extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            user: {
+                name         : 'Eric',
+                unreadCount  : 4,
+                lastLoginTime: Date.now() - 1000 * 5,
+            },
+        };
+    }
+
+    render() {
+        return (
+            <div>
+                <h1>
+                    <FormattedMessage
+                        id="app.title"
+                        defaultMessage="React Intl Nested Messages Example"
+                    />
+                </h1>
+
+                <IntlProvider
+                    messages={this.props.getIntlMessages('greeting')}
+                >
+                    <Greeting {...this.state.user} />
+                </IntlProvider>
+            </div>
+        );
+    }
+}
+
+App.propTypes = {
+    getIntlMessages: PropTypes.func.isRequired,
+};
+
+export default App;

--- a/examples/nested/src/client/components/widgets/greeting.js
+++ b/examples/nested/src/client/components/widgets/greeting.js
@@ -1,0 +1,42 @@
+import React, {PropTypes} from 'react';
+import {
+    FormattedMessage,
+    FormattedNumber,
+    FormattedRelative,
+} from 'react-intl';
+
+const Greeting = ({name, unreadCount, lastLoginTime}) => (
+    <p>
+        <FormattedMessage
+            id="greeting.welcome_message"
+            defaultMessage={`
+                Welcome {name}, you have received {unreadCount, plural,
+                    =0 {no new messages}
+                    one {{formattedUnreadCount} new message}
+                    other {{formattedUnreadCount} new messages}
+                } since {formattedLastLoginTime}.
+            `}
+            values={{
+                name: <b>{name}</b>,
+                unreadCount: unreadCount,
+                formattedUnreadCount: (
+                    <b><FormattedNumber value={unreadCount} /></b>
+                ),
+                formattedLastLoginTime: (
+                    <FormattedRelative
+                        value={lastLoginTime}
+                        updateInterval={1000}
+                    />
+                ),
+            }}
+        />
+    </p>
+);
+
+Greeting.propTypes = {
+    name         : PropTypes.node.isRequired,
+    unreadCount  : PropTypes.number.isRequired,
+    lastLoginTime: PropTypes.any.isRequired,
+};
+
+export default Greeting;

--- a/examples/nested/src/client/index.js
+++ b/examples/nested/src/client/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {addLocaleData, IntlProvider} from 'react-intl';
+import enLocaleData from 'react-intl/locale-data/en';
+import App from './components/app';
+
+addLocaleData(enLocaleData);
+
+const {locale, messages} = window.App;
+
+ReactDOM.render(
+    <IntlProvider
+        locale={locale}
+        messages={messages.app}
+    >
+        <App getIntlMessages={(namespace) => messages[namespace]} />
+    </IntlProvider>,
+    document.getElementById('container')
+);

--- a/examples/nested/src/server/index.js
+++ b/examples/nested/src/server/index.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import {sync as globSync} from 'glob';
+import {readFileSync} from 'fs';
+import * as p from 'path';
+import serialize from 'serialize-javascript';
+
+const messages = globSync('./build/lang/*/en-US.json')
+    .map((filename) => [
+        p.basename(p.dirname(filename)),
+        readFileSync(filename, 'utf8'),
+    ])
+    .map(([namespace, file]) => [namespace, JSON.parse(file)])
+    .reduce((messages, [namespace, collection]) => {
+        messages[namespace] = collection;
+        return messages;
+    }, {});
+
+const app = express();
+
+app.get('/', (req, res) => {
+    res.send(
+`
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>React Intl Nested Messages Example</title>
+</head>
+<body>
+    <div id="container"></div>
+    <script>
+        window.App = ${serialize({locale: 'en-US', messages})};
+    </script>
+    <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=Intl.~locale.en"></script>
+    <script src="react/dist/react.js"></script>
+    <script src="react-dom/dist/react-dom.js"></script>
+    <script src="bundle.js"></script>
+</body>
+</html>
+`
+    );
+});
+
+app.use(express.static('build'));
+app.use(express.static('../../node_modules'));
+
+app.listen(8080, () => {
+    console.log('React Intl Example server listening at: http://localhost:8080');
+});

--- a/examples/translations/package.json
+++ b/examples/translations/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "clean": "rimraf build",
+    "clean": "../../node_modules/.bin/rimraf build",
     "build:bundle": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify src/client/index.js -d -t babelify -t browserify-shim > build/bundle.js",
     "build:langs": "../../node_modules/.bin/babel-node scripts/translate.js",
     "build": "npm run build:bundle && npm run build:langs",

--- a/src/components/intl.js
+++ b/src/components/intl.js
@@ -10,11 +10,11 @@ import IntlRelativeFormat from 'intl-relativeformat';
 import IntlPluralFormat from '../plural';
 import createFormatCache from 'intl-format-cache';
 import {shouldIntlComponentUpdate} from '../utils';
-import {intlPropTypes, intlFormatPropTypes, intlShape} from '../types';
+import {intlConfigPropTypes, intlFormatPropTypes, intlShape} from '../types';
 import * as format from '../format';
 import {hasLocaleData} from '../locale-data-registry';
 
-const intlPropNames       = Object.keys(intlPropTypes);
+const intlConfigPropNames = Object.keys(intlConfigPropTypes);
 const intlFormatPropNames = Object.keys(intlFormatPropTypes);
 
 export default class IntlProvider extends Component {
@@ -44,7 +44,7 @@ export default class IntlProvider extends Component {
     }
 
     getConfig() {
-        let config = intlPropNames.reduce((config, name) => {
+        let config = intlConfigPropNames.reduce((config, name) => {
             config[name] = this.props[name];
             return config;
         }, {});
@@ -121,7 +121,7 @@ IntlProvider.childContextTypes = {
 };
 
 IntlProvider.propTypes = {
-    ...intlPropTypes,
+    ...intlConfigPropTypes,
     children  : PropTypes.element.isRequired,
     initialNow: PropTypes.any,
 };

--- a/src/locale-data-registry.js
+++ b/src/locale-data-registry.js
@@ -22,5 +22,5 @@ export function addLocaleData(data = []) {
 }
 
 export function hasLocaleData(locale) {
-    return !!registeredLocales[locale.toLowerCase()];
+    return !!registeredLocales[locale && locale.toLowerCase()];
 }

--- a/src/types.js
+++ b/src/types.js
@@ -9,7 +9,7 @@ import {PropTypes} from 'react';
 const {bool, number, string, func, object, oneOf, shape} = PropTypes;
 
 export const intlConfigPropTypes = {
-    locale  : string.isRequired,
+    locale  : string,
     formats : object,
     messages: object,
 

--- a/src/types.js
+++ b/src/types.js
@@ -8,7 +8,7 @@ import {PropTypes} from 'react';
 
 const {bool, number, string, func, object, oneOf, shape} = PropTypes;
 
-export const intlPropTypes = {
+export const intlConfigPropTypes = {
     locale  : string.isRequired,
     formats : object,
     messages: object,
@@ -28,7 +28,7 @@ export const intlFormatPropTypes = {
 };
 
 export const intlShape = shape({
-    ...intlPropTypes,
+    ...intlConfigPropTypes,
     ...intlFormatPropTypes,
     now: func.isRequired,
 });


### PR DESCRIPTION
This makes it easier and more intuitive to nest `<IntlProvider>` elements by looking for `context.intl` and merging it with its own `props`.

A common use case is for apps whose UIs are split among multiple packages, each with their own translated messages. These chunks of UI can now be wrapped with a nested `<IntlProvider>` configured to only expose the translated message for that package's root component.

**See:** `examples/nested/` for a simple example using nested `<IntlProvider>` elements.