### PR TITLE
Allow introspection access to the component wrapped by InjectIntl

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -55,5 +55,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
         intl: intlShape,
     };
 
+    InjectIntl.WrappedComponent = WrappedComponent;
+
     return InjectIntl;
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -49,7 +49,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
         }
     }
 
-    InjectIntl.displayName = `IntjectIntl(${getDisplayName(WrappedComponent)})`;
+    InjectIntl.displayName = `InjectIntl(${getDisplayName(WrappedComponent)})`;
 
     InjectIntl.contextTypes = {
         intl: intlShape,

--- a/test/unit/inject-intl.js
+++ b/test/unit/inject-intl.js
@@ -1,0 +1,11 @@
+import expect from 'expect';
+import * as ReactIntl from '../../src/react-intl';
+import React from 'react';
+
+describe('injectIntl', () => {
+    it('allows introspection access to the wrapped component', () => {
+        const wrapped = React.createElement('div', 'hello');
+        const injected = ReactIntl.injectIntl(wrapped);
+        expect(injected.WrappedComponent).toBe(wrapped);
+    });
+});

--- a/test/unit/react-intl-with-locales.js
+++ b/test/unit/react-intl-with-locales.js
@@ -12,7 +12,7 @@ describe('react-intl-with-locales', () => {
         });
 
         it('exports `injectIntl`', () => {
-            expect(ReactIntl.defineMessages).toBeA('function');
+            expect(ReactIntl.injectIntl).toBeA('function');
         });
 
         describe('React Components', () => {

--- a/test/unit/react-intl.js
+++ b/test/unit/react-intl.js
@@ -12,7 +12,7 @@ describe('react-intl', () => {
         });
 
         it('exports `injectIntl`', () => {
-            expect(ReactIntl.defineMessages).toBeA('function');
+            expect(ReactIntl.injectIntl).toBeA('function');
         });
 
         describe('React Components', () => {


### PR DESCRIPTION
Access to the wrapped components (when not mounted) is useful for universal apps; for instance [@erikras' universal example](https://github.com/erikras/react-redux-universal-hot-example/blob/61610b154fa82d274d89f6cd1f0818edce5a8f6c/src/helpers/getDataDependencies.js) depends on being able to find certain static functions.

This PR also fixes an incidental typo in `injectIntl` and a couple mis-copypasted tests.