### PR TITLE
Refactor nested example to move <IntlProvider> into widget

### DIFF
--- a/examples/nested/src/client/components/app.js
+++ b/examples/nested/src/client/components/app.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {IntlProvider, FormattedMessage} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 import Greeting from './widgets/greeting';
 
 class App extends Component {
@@ -24,12 +24,11 @@ class App extends Component {
                         defaultMessage="React Intl Nested Messages Example"
                     />
                 </h1>
-
-                <IntlProvider
+                <Greeting
                     messages={this.props.getIntlMessages('greeting')}
-                >
-                    <Greeting {...this.state.user} />
-                </IntlProvider>
+                    messages={this.context.intl.locale}
+                    {...this.state.user}
+                />
             </div>
         );
     }

--- a/examples/nested/src/client/components/widgets/greeting.js
+++ b/examples/nested/src/client/components/widgets/greeting.js
@@ -3,37 +3,42 @@ import {
     FormattedMessage,
     FormattedNumber,
     FormattedRelative,
+    IntlProvider,
 } from 'react-intl';
 
-const Greeting = ({name, unreadCount, lastLoginTime}) => (
-    <p>
-        <FormattedMessage
-            id="greeting.welcome_message"
-            defaultMessage={`
-                Welcome {name}, you have received {unreadCount, plural,
-                    =0 {no new messages}
-                    one {{formattedUnreadCount} new message}
-                    other {{formattedUnreadCount} new messages}
-                } since {formattedLastLoginTime}.
-            `}
-            values={{
-                name: <b>{name}</b>,
-                unreadCount: unreadCount,
-                formattedUnreadCount: (
-                    <b><FormattedNumber value={unreadCount} /></b>
-                ),
-                formattedLastLoginTime: (
-                    <FormattedRelative
-                        value={lastLoginTime}
-                        updateInterval={1000}
-                    />
-                ),
-            }}
-        />
-    </p>
+const Greeting = ({messages, locale, name, unreadCount, lastLoginTime}) => (
+    <IntlProvider messages={messages} locale={locale}>
+        <p>
+            <FormattedMessage
+                id="greeting.welcome_message"
+                defaultMessage={`
+                    Welcome {name}, you have received {unreadCount, plural,
+                        =0 {no new messages}
+                        one {{formattedUnreadCount} new message}
+                        other {{formattedUnreadCount} new messages}
+                    } since {formattedLastLoginTime}.
+                `}
+                values={{
+                    name: <b>{name}</b>,
+                    unreadCount: unreadCount,
+                    formattedUnreadCount: (
+                        <b><FormattedNumber value={unreadCount} /></b>
+                    ),
+                    formattedLastLoginTime: (
+                        <FormattedRelative
+                            value={lastLoginTime}
+                            updateInterval={1000}
+                        />
+                    ),
+                }}
+            />
+        </p>
+    </IntlProvider>
 );
 
 Greeting.propTypes = {
+    messages     : PropTypes.object,
+    locale       : PropTypes.string,
     name         : PropTypes.node.isRequired,
     unreadCount  : PropTypes.number.isRequired,
     lastLoginTime: PropTypes.any.isRequired,


### PR DESCRIPTION
Refactor the example to move the `<IntlProvider>` inside of the widget. Without this, the widget will be unusable as a standalone component.

_**Note**_: This is best viewed with the whitespace flag. Indenting made the diff look much bigger than it is.
