### PR TITLE
Check for preset locale data in hasLocaleData()

### DIFF
--- a/src/locale-data-registry.js
+++ b/src/locale-data-registry.js
@@ -22,5 +22,6 @@ export function addLocaleData(data = []) {
 }
 
 export function hasLocaleData(locale) {
-    return !!registeredLocales[locale && locale.toLowerCase()];
+    locale = locale && locale.toLowerCase();
+    return !!registeredLocales[locale] || !!(IntlMessageFormat.__localeData__[locale] && IntlRelativeFormat.__localeData__[locale]);
 }


### PR DESCRIPTION
For projects that do not want to use `react-intl`'s addLocaleData method and instead rely on IntlMessageFormat & IntlRelativeFormat own methods.

This PR adds an extra check to see if the locale has already been set on both libs in case it is not found in the registeredLocales hash.