### PR TITLE
Correct the CLDR acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ ReactDOM.render(
 
 This example would render: "Hello **Eric**, you have 1,000 messages." into the container element on the page.
 
-**CDLR pluralization rules:** In some languages you have more then `one` and `other`. For example in `ru` there are the following plural rules: `one`, `few`, `many` and `other`.
-Check out the official CDLR documentation from unicode.org http://www.unicode.org/cldr/charts/27/supplemental/language_plural_rules.html for all languages.
+**CLDR pluralization rules:** In some languages you have more then `one` and `other`. For example in `ru` there are the following plural rules: `one`, `few`, `many` and `other`.
+Check out the official CLDR documentation from unicode.org http://www.unicode.org/cldr/charts/27/supplemental/language_plural_rules.html for all languages.
 
 _Note:  You could also write ` =0 { No comments yet }`_
 


### PR DESCRIPTION
Pretty insignificant. Might save someone time searching.

The "Common Locale Data Repository" acronym was incorrectly represented as CDLR, instead of CLDR