### PR TITLE
Add styling to component FormattedHTMLMessage

### DIFF
--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -19,8 +19,12 @@ export default class FormattedHTMLMessage extends Component {
     }
 
     shouldComponentUpdate(nextProps, ...next) {
-        const {values}             = this.props;
-        const {values: nextValues} = nextProps;
+        const {values, style, className} = this.props;
+        const {
+            values: nextValues, 
+            style: nextStyle, 
+            className: nextClassName,
+        } = nextProps;
 
         if (!shallowEquals(nextValues, values) || 
             !shallowEquals(nextStyle, style) || 

--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -22,7 +22,9 @@ export default class FormattedHTMLMessage extends Component {
         const {values}             = this.props;
         const {values: nextValues} = nextProps;
 
-        if (!shallowEquals(nextValues, values)) {
+        if (!shallowEquals(nextValues, values) || 
+            !shallowEquals(nextStyle, style) || 
+            !shallowEquals(nextClassName, className)) {
             return true;
         }
 
@@ -47,6 +49,8 @@ export default class FormattedHTMLMessage extends Component {
             values: rawValues,
             tagName,
             children,
+            style,
+            className,
         } = this.props;
 
         let descriptor           = {id, description, defaultMessage};
@@ -68,6 +72,8 @@ export default class FormattedHTMLMessage extends Component {
             dangerouslySetInnerHTML: {
                 __html: formattedHTMLMessage,
             },
+            style, 
+            className,
         });
     }
 }
@@ -80,9 +86,11 @@ FormattedHTMLMessage.contextTypes = {
 
 FormattedHTMLMessage.propTypes = {
     ...messageDescriptorPropTypes,
-    values  : PropTypes.object,
-    tagName : PropTypes.string,
-    children: PropTypes.func,
+    values   : PropTypes.object,
+    tagName  : PropTypes.string,
+    children : PropTypes.func,
+    style    : PropTypes.any,
+    className: PropTypes.any,
 };
 
 FormattedHTMLMessage.defaultProps = {


### PR DESCRIPTION
Add ability to pass `style`s and `className`s to FormattedHTMLMessage via props.