### PR TITLE
Add ability to pass styles and classNames to FormattedPlural via props.

### DIFF
--- a/src/components/number.js
+++ b/src/components/number.js
@@ -6,7 +6,11 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, numberFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {
+    invariantIntlContext,
+    shouldIntlComponentUpdate,
+    prepareIntlStyleOption
+} from '../utils';
 
 export default class FormattedNumber extends Component {
     constructor(props, context) {
@@ -22,7 +26,7 @@ export default class FormattedNumber extends Component {
         const {formatNumber}    = this.context.intl;
         const {value, children} = this.props;
 
-        let formattedNumber = formatNumber(value, this.props);
+        let formattedNumber = formatNumber(value, prepareIntlStyleOption(this.props) );
 
         if (typeof children === 'function') {
             return children(formattedNumber);

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -9,7 +9,7 @@ import {intlShape, numberFormatPropTypes} from '../types';
 import {
     invariantIntlContext,
     shouldIntlComponentUpdate,
-    prepareIntlStyleOption
+    prepareIntlStyleOption,
 } from '../utils';
 
 export default class FormattedNumber extends Component {

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -6,7 +6,11 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, pluralFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {
+    invariantIntlContext,
+    shouldIntlComponentUpdate,
+    prepareIntlStyleOption,
+} from '../utils';
 
 export default class FormattedPlural extends Component {
     constructor(props, context) {
@@ -22,7 +26,7 @@ export default class FormattedPlural extends Component {
         const {formatPlural}           = this.context.intl;
         const {value, other, children} = this.props;
 
-        let pluralCategory  = formatPlural(value, this.props);
+        let pluralCategory  = formatPlural(value, prepareIntlStyleOption(this.props));
         let formattedPlural = this.props[pluralCategory] || other;
 
         if (typeof children === 'function') {
@@ -54,5 +58,5 @@ FormattedPlural.propTypes = {
 };
 
 FormattedPlural.defaultProps = {
-    style: 'cardinal',
+    intlStyle: 'cardinal',
 };

--- a/src/components/plural.js
+++ b/src/components/plural.js
@@ -23,8 +23,8 @@ export default class FormattedPlural extends Component {
     }
 
     render() {
-        const {formatPlural}           = this.context.intl;
-        const {value, other, children} = this.props;
+        const {formatPlural} = this.context.intl;
+        const {value, other, children, style, className} = this.props;
 
         let pluralCategory  = formatPlural(value, prepareIntlStyleOption(this.props));
         let formattedPlural = this.props[pluralCategory] || other;
@@ -33,7 +33,7 @@ export default class FormattedPlural extends Component {
             return children(formattedPlural);
         }
 
-        return <span>{formattedPlural}</span>;
+        return <span style={style} className={className}>{formattedPlural}</span>;
     }
 }
 
@@ -54,7 +54,9 @@ FormattedPlural.propTypes = {
     few  : PropTypes.node,
     many : PropTypes.node,
 
-    children: PropTypes.func,
+    children : PropTypes.func,
+    style    : PropTypes.any,
+    className: PropTypes.any,
 };
 
 FormattedPlural.defaultProps = {

--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -6,7 +6,11 @@
 
 import React, {Component, PropTypes} from 'react';
 import {intlShape, relativeFormatPropTypes} from '../types';
-import {invariantIntlContext, shouldIntlComponentUpdate} from '../utils';
+import {
+    invariantIntlContext,
+    shouldIntlComponentUpdate,
+    prepareIntlStyleOption,
+} from '../utils';
 
 const SECOND = 1000;
 const MINUTE = 1000 * 60;
@@ -110,10 +114,10 @@ export default class FormattedRelative extends Component {
         const {formatRelative}  = this.context.intl;
         const {value, children} = this.props;
 
-        let formattedRelative = formatRelative(value, {
+        let formattedRelative = formatRelative(value, prepareIntlStyleOption({
             ...this.props,
             ...this.state,
-        });
+        }));
 
         if (typeof children === 'function') {
             return children(formattedRelative);

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,3 +74,23 @@ export function shouldIntlComponentUpdate(
         !shallowEquals(nextIntl, intl)
     );
 }
+
+export function prepareIntlStyleOption(props) {
+    const hasStyle     = 'style' in props;
+    const hasIntlStyle = 'intlStyle' in props;
+
+    if (!hasStyle && !hasIntlStyle) {
+        return props;
+    } else {
+        let newProps = {...props};
+
+        if (hasIntlStyle) {
+            newProps['style'] = newProps['intlStyle'];
+            delete newProps['intlStyle'];
+        } else if (hasStyle) {
+            delete newProps['style'];
+        }
+
+        return newProps;
+    }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,16 +81,16 @@ export function prepareIntlStyleOption(props) {
 
     if (!hasStyle && !hasIntlStyle) {
         return props;
-    } else {
-        let newProps = {...props};
-
-        if (hasIntlStyle) {
-            newProps['style'] = newProps['intlStyle'];
-            delete newProps['intlStyle'];
-        } else if (hasStyle) {
-            delete newProps['style'];
-        }
-
-        return newProps;
     }
+
+    let newProps = {...props};
+
+    if (hasIntlStyle) {
+        newProps['style'] = newProps['intlStyle'];
+        delete newProps['intlStyle'];
+    } else if (hasStyle) {
+        delete newProps['style'];
+    }
+
+    return newProps;
 }

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,27 @@
+import expect from 'expect';
+import * as utils from '../../src/utils';
+
+describe('utils', () => {
+    describe('prepareIntlStyleOption()', () => {
+        it('should remove style prop, which decorates DOM-elements', () => {
+            const props = {a: 1, style: {}};
+            expect(utils.prepareIntlStyleOption(props)['a']).toBe(1);
+            expect(utils.prepareIntlStyleOption(props)['style']).toNotExist();
+        });
+
+        it('should rename intlStyle prop to style', () => {
+            const props = {a: 1, intlStyle: {b: 2}};
+            expect(utils.prepareIntlStyleOption(props)['a']).toBe(1);
+            expect(utils.prepareIntlStyleOption(props)['intlStyle']).toNotExist();
+            expect(utils.prepareIntlStyleOption(props)['style']['b']).toBe(2);
+        });
+
+        it('should replace style by intlStyle prop', () => {
+            const props = {a: 1, style: {c: 3}, intlStyle: {b: 2}};
+            expect(utils.prepareIntlStyleOption(props)['a']).toBe(1);
+            expect(utils.prepareIntlStyleOption(props)['intlStyle']).toNotExist();
+            expect(utils.prepareIntlStyleOption(props)['style']['b']).toBe(2);
+            expect(utils.prepareIntlStyleOption(props)['style']['c']).toNotExist();
+        });
+    });
+});


### PR DESCRIPTION
Also in components renamed property `style` to `intlStyle`.
Property name `style` should be used for decorating elements via css rules.

Internaly `intlStyle` property renamed to `style` when component props passing to internalization methods.