### PR TITLE
Add default options for time formatting

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -72,6 +72,15 @@ export function formatTime(config, state, value, options = {}) {
         options, defaults
     );
 
+    // When no formatting options have been specified, default to outputting a
+    // time; e.g.: "9:42 AM".
+    if (Object.keys(filteredOptions).length === 0) {
+        filteredOptions = {
+            hour  : 'numeric',
+            minute: 'numeric',
+        };
+    }
+
     return state.getDateTimeFormat(locale, filteredOptions).format(date);
 }
 

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -182,7 +182,11 @@ describe('format API', () => {
         let formatTime;
 
         beforeEach(() => {
-            df = new Intl.DateTimeFormat(config.locale);
+            df = new Intl.DateTimeFormat(config.locale, {
+                hour: 'numeric',
+                minute: 'numeric',
+            });
+
             formatTime = f.formatTime.bind(null, config, state);
         });
 
@@ -254,8 +258,6 @@ describe('format API', () => {
             it('handles missing named formats and warns', () => {
                 const date   = new Date();
                 const format = 'missing';
-
-                df = new Intl.DateTimeFormat(config.locale);
 
                 expect(formatTime(date, {format})).toBe(df.format(date));
                 expect(consoleError.calls.length).toBe(1);


### PR DESCRIPTION
This makes `<FormattedTime>` and `formatTime()` with no options produce a formatted time by default; e.g.: "9:42 AM"

Fixes #263