### PR TITLE
Integration merging static properties in injectIntl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ lib/
 locale-data/
 node_modules/
 src/en.js
+.idea/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "global:React"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^1.0.3",
     "intl-format-cache": "^2.0.5",
     "intl-messageformat": "^1.2.0",
     "intl-relativeformat": "^1.2.0",

--- a/src/inject.js
+++ b/src/inject.js
@@ -11,6 +11,7 @@ import React, {Component} from 'react';
 import invariant from 'invariant';
 import {intlShape} from './types';
 import {invariantIntlContext} from './utils';
+import hoistStatics from 'hoist-non-react-statics';
 
 function getDisplayName(Component) {
     return Component.displayName || Component.name || 'Component';
@@ -57,5 +58,5 @@ export default function injectIntl(WrappedComponent, options = {}) {
 
     InjectIntl.WrappedComponent = WrappedComponent;
 
-    return InjectIntl;
+    return hoistStatics(WrappedComponent, InjectIntl);
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -58,5 +58,5 @@ export default function injectIntl(WrappedComponent, options = {}) {
 
     InjectIntl.WrappedComponent = WrappedComponent;
 
-    return hoistStatics(WrappedComponent, InjectIntl);
+    return hoistStatics(InjectIntl, WrappedComponent);
 }


### PR DESCRIPTION
Hi, I solved the problem of maintaining the static properties of the component after the decoration.

Problem:
```
import * as React from "react"
import {injectIntl} from "react-intl"

@injectIntl
class MyComponent extends React.Component {
     static myProperty = "abc"
     ....
}

console.log(MyComponent.myProperty) // not exists
```