### PR TITLE
Pre-emptively remove 0.14 peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "intl-relativeformat": "^1.2.0",
     "invariant": "^2.1.1"
   },
-  "peerDependencies": {
-    "react": "^0.14.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-eslint": "^5.0.0-beta4",


### PR DESCRIPTION
React 0.15’s first alpha release has been published. This is an effort to avoid requiring all consumers to hold off on updating or suffer through npm’s warn peer dep mismatch message.