### PR TITLE
Change children PropType to node

### DIFF
--- a/src/components/intl.js
+++ b/src/components/intl.js
@@ -154,6 +154,9 @@ IntlProvider.childContextTypes = {
 
 IntlProvider.propTypes = {
     ...intlConfigPropTypes,
-    children  : PropTypes.element.isRequired,
+    children  : PropTypes.oneOfType([
+        PropTypes.arrayOf(_react.PropTypes.node),
+        PropTypes.node
+    ]).isRequired,
     initialNow: PropTypes.any,
 };


### PR DESCRIPTION
This change will give ability to use react-intl with react-router.
For example, follwing code will work as expected:
```
const root = (
  <IntlProvider {...intlData}>
    <Router history={browserHistory}>
      <Route path="/" component={App}>
        <Route path="auth" component={Login}/>
        <IndexRoute component={Main} onEnter={requireAuth}/>
      </Route>
    </Router>
  </IntlProvider>
);

render(root, appRootElemet);
```