### PR TITLE
Catch errors in format functions and fallback

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -44,7 +44,17 @@ export function formatDate(config, state, value, options = {}) {
     let defaults        = format && getNamedFormat(formats, 'date', format);
     let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
 
-    return state.getDateTimeFormat(locale, filteredOptions).format(date);
+    try {
+        return state.getDateTimeFormat(locale, filteredOptions).format(date);
+    } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error(
+                `[React Intl] Error formatting date.\n${e}`
+            );
+        }
+    }
+
+    return String(date);
 }
 
 export function formatTime(config, state, value, options = {}) {
@@ -64,7 +74,17 @@ export function formatTime(config, state, value, options = {}) {
         };
     }
 
-    return state.getDateTimeFormat(locale, filteredOptions).format(date);
+    try {
+        return state.getDateTimeFormat(locale, filteredOptions).format(date);
+    } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error(
+                `[React Intl] Error formatting time.\n${e}`
+            );
+        }
+    }
+
+    return String(date);
 }
 
 export function formatRelative(config, state, value, options = {}) {
@@ -76,9 +96,19 @@ export function formatRelative(config, state, value, options = {}) {
     let defaults        = format && getNamedFormat(formats, 'relative', format);
     let filteredOptions = filterProps(options, RELATIVE_FORMAT_OPTIONS, defaults);
 
-    return state.getRelativeFormat(locale, filteredOptions).format(date, {
-        now: isFinite(now) ? now : state.now(),
-    });
+    try {
+        return state.getRelativeFormat(locale, filteredOptions).format(date, {
+            now: isFinite(now) ? now : state.now(),
+        });
+    } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error(
+                `[React Intl] Error formatting relative time.\n${e}`
+            );
+        }
+    }
+
+    return String(date);
 }
 
 export function formatNumber(config, state, value, options = {}) {
@@ -88,7 +118,17 @@ export function formatNumber(config, state, value, options = {}) {
     let defaults        = format && getNamedFormat(formats, 'number', format);
     let filteredOptions = filterProps(options, NUMBER_FORMAT_OPTIONS, defaults);
 
-    return state.getNumberFormat(locale, filteredOptions).format(value);
+    try {
+        return state.getNumberFormat(locale, filteredOptions).format(value);
+    } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error(
+                `[React Intl] Error formatting number.\n${e}`
+            );
+        }
+    }
+
+    return String(value);
 }
 
 export function formatPlural(config, state, value, options = {}) {
@@ -96,7 +136,17 @@ export function formatPlural(config, state, value, options = {}) {
 
     let filteredOptions = filterProps(options, PLURAL_FORMAT_OPTIONS);
 
-    return state.getPluralFormat(locale, filteredOptions).format(value);
+    try {
+        return state.getPluralFormat(locale, filteredOptions).format(value);
+    } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error(
+                `[React Intl] Error formatting plural.\n${e}`
+            );
+        }
+    }
+
+    return 'other';
 }
 
 export function formatMessage(config, state, messageDescriptor = {}, values = {}) {

--- a/test/functional/format.js
+++ b/test/functional/format.js
@@ -45,7 +45,7 @@ export default function (ReactIntl) {
             expect(renderer.getRenderOutput()).toEqualJSX(
                 <span>
                     {
-                        `${hours > 12 ? (hours % 12) : hours}:` +
+                        `${hours > 12 ? (hours % 12) : (hours || '12')}:` +
                         `${minutes < 10 ? `0${minutes}` : minutes} ` +
                         `${hours < 12 ? 'AM' : 'PM'}`
                     }

--- a/test/unit/components/date.js
+++ b/test/unit/components/date.js
@@ -35,9 +35,15 @@ describe('<FormattedDate>', () => {
     it('requires a finite `value` prop', () => {
         const {intl} = intlProvider.getChildContext();
 
-        expect(() => renderer.render(<FormattedDate />, {intl})).toThrow(RangeError);
+        renderer.render(<FormattedDate value={0} />, {intl});
         expect(isFinite(0)).toBe(true);
-        expect(() => renderer.render(<FormattedDate value={0} />, {intl})).toNotThrow();
+        expect(consoleError.calls.length).toBe(0);
+
+        renderer.render(<FormattedDate />, {intl});
+        expect(consoleError.calls.length).toBe(1);
+        expect(consoleError.calls[0].arguments[0]).toContain(
+            '[React Intl] Error formatting date.\nRangeError'
+        );
     });
 
     it('renders a formatted date in a <span>', () => {
@@ -99,11 +105,16 @@ describe('<FormattedDate>', () => {
         );
     });
 
-    it('throws on invalid Intl.DateTimeFormat options', () => {
+    it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
         const {intl} = intlProvider.getChildContext();
         const el = <FormattedDate value={0} year="invalid" />;
 
-        expect(() => renderer.render(el, {intl})).toThrow();
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <span>{String(new Date(0))}</span>
+        );
+
+        expect(consoleError.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/components/number.js
+++ b/test/unit/components/number.js
@@ -96,11 +96,16 @@ describe('<FormattedNumber>', () => {
         );
     });
 
-    it('throws on invalid Intl.NumberFormat options', () => {
+    it('fallsback and warns on invalid Intl.NumberFormat options', () => {
         const {intl} = intlProvider.getChildContext();
         const el = <FormattedNumber value={0} style="invalid" />;
 
-        expect(() => renderer.render(el, {intl})).toThrow();
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <span>{String(0)}</span>
+        );
+
+        expect(consoleError.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/components/relative.js
+++ b/test/unit/components/relative.js
@@ -43,9 +43,15 @@ describe('<FormattedRelative>', () => {
     it('requires a finite `value` prop', () => {
         const {intl} = intlProvider.getChildContext();
 
-        expect(() => renderer.render(<FormattedRelative />, {intl})).toThrow(RangeError);
+        renderer.render(<FormattedRelative value={0} />, {intl});
         expect(isFinite(0)).toBe(true);
-        expect(() => renderer.render(<FormattedRelative value={0} />, {intl})).toNotThrow();
+        expect(consoleError.calls.length).toBe(0);
+
+        renderer.render(<FormattedRelative />, {intl});
+        expect(consoleError.calls.length).toBe(1);
+        expect(consoleError.calls[0].arguments[0]).toContain(
+            '[React Intl] Error formatting relative time.\nRangeError'
+        );
     });
 
     it('renders a formatted relative time in a <span>', () => {
@@ -107,11 +113,16 @@ describe('<FormattedRelative>', () => {
         );
     });
 
-    it('throws on invalid IntlRelativeFormat options', () => {
+    it('fallsback and warns on invalid IntlRelativeFormat options', () => {
         const {intl} = intlProvider.getChildContext();
         const el = <FormattedRelative value={0} units="invalid" />;
 
-        expect(() => renderer.render(el, {intl})).toThrow();
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <span>{String(new Date(0))}</span>
+        );
+
+        expect(consoleError.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/components/time.js
+++ b/test/unit/components/time.js
@@ -35,9 +35,15 @@ describe('<FormattedTime>', () => {
     it('requires a finite `value` prop', () => {
         const {intl} = intlProvider.getChildContext();
 
-        expect(() => renderer.render(<FormattedTime />, {intl})).toThrow(RangeError);
+        renderer.render(<FormattedTime value={0} />, {intl});
         expect(isFinite(0)).toBe(true);
-        expect(() => renderer.render(<FormattedTime value={0} />, {intl})).toNotThrow();
+        expect(consoleError.calls.length).toBe(0);
+
+        renderer.render(<FormattedTime />, {intl});
+        expect(consoleError.calls.length).toBe(1);
+        expect(consoleError.calls[0].arguments[0]).toContain(
+            '[React Intl] Error formatting time.\nRangeError'
+        );
     });
 
     it('renders a formatted time in a <span>', () => {
@@ -99,11 +105,16 @@ describe('<FormattedTime>', () => {
         );
     });
 
-    it('throws on invalid Intl.DateTimeFormat options', () => {
+    it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
         const {intl} = intlProvider.getChildContext();
         const el = <FormattedTime value={0} hour="invalid" />;
 
-        expect(() => renderer.render(el, {intl})).toThrow();
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <span>{String(new Date(0))}</span>
+        );
+
+        expect(consoleError.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -100,13 +100,18 @@ describe('format API', () => {
             formatDate = f.formatDate.bind(null, config, state);
         });
 
-        it('throws when no value is provided', () => {
-            expect(formatDate).toThrow();
+        it('fallsback and warns when no value is provided', () => {
+            expect(formatDate()).toBe('Invalid Date');
+            expect(consoleError.calls.length).toBe(1);
+            expect(consoleError.calls[0].arguments[0]).toContain(
+                '[React Intl] Error formatting date.\nRangeError'
+            );
         });
 
-        it('throws when a non-finite value is provided', () => {
-            expect(() => formatDate(NaN)).toThrow();
-            expect(() => formatDate('')).toThrow();
+        it('fallsback and warns when a non-finite value is provided', () => {
+            expect(formatDate(NaN)).toBe('Invalid Date');
+            expect(formatDate('')).toBe('Invalid Date');
+            expect(consoleError.calls.length).toBe(2);
         });
 
         it('formats falsy finite values', () => {
@@ -137,8 +142,12 @@ describe('format API', () => {
                 expect(() => formatDate(0, {year: 'numeric'})).toNotThrow();
             });
 
-            it('throws on invalid Intl.DateTimeFormat options', () => {
-                expect(() => formatDate(0, {year: 'invalid'})).toThrow();
+            it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
+                expect(formatDate(0, {year: 'invalid'})).toBe(String(new Date(0)));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toContain(
+                    '[React Intl] Error formatting date.\nRangeError'
+                );
             });
 
             it('uses configured named formats', () => {
@@ -193,13 +202,18 @@ describe('format API', () => {
             formatTime = f.formatTime.bind(null, config, state);
         });
 
-        it('throws when no value is provided', () => {
-            expect(formatTime).toThrow();
+        it('fallsback and warns when no value is provided', () => {
+            expect(formatTime()).toBe('Invalid Date');
+            expect(consoleError.calls.length).toBe(1);
+            expect(consoleError.calls[0].arguments[0]).toContain(
+                '[React Intl] Error formatting time.\nRangeError'
+            );
         });
 
-        it('throws when a non-finite value is provided', () => {
-            expect(() => formatTime(NaN)).toThrow();
-            expect(() => formatTime('')).toThrow();
+        it('fallsback and warns when a non-finite value is provided', () => {
+            expect(formatTime(NaN)).toBe('Invalid Date');
+            expect(formatTime('')).toBe('Invalid Date');
+            expect(consoleError.calls.length).toBe(2);
         });
 
         it('formats falsy finite values', () => {
@@ -230,8 +244,12 @@ describe('format API', () => {
                 expect(() => formatTime(0, {hour: '2-digit'})).toNotThrow();
             });
 
-            it('throws on invalid Intl.DateTimeFormat options', () => {
-                expect(() => formatTime(0, {hour: 'invalid'})).toThrow();
+            it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
+                expect(formatTime(0, {hour: 'invalid'})).toBe(String(new Date(0)));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toContain(
+                    '[React Intl] Error formatting time.\nRangeError'
+                );
             });
 
             it('uses configured named formats', () => {
@@ -282,13 +300,18 @@ describe('format API', () => {
             formatRelative = f.formatRelative.bind(null, config, state);
         });
 
-        it('throws when no value is provided', () => {
-            expect(formatRelative).toThrow();
+        it('fallsback and warns when no value is provided', () => {
+            expect(formatRelative()).toBe('Invalid Date');
+            expect(consoleError.calls.length).toBe(1);
+            expect(consoleError.calls[0].arguments[0]).toContain(
+                '[React Intl] Error formatting relative time.\nRangeError'
+            );
         });
 
-        it('throws when a non-finite value is provided', () => {
-            expect(() => formatRelative(NaN)).toThrow();
-            expect(() => formatRelative('')).toThrow();
+        it('fallsback and warns when a non-finite value is provided', () => {
+            expect(formatRelative(NaN)).toBe('Invalid Date');
+            expect(formatRelative('')).toBe('Invalid Date');
+            expect(consoleError.calls.length).toBe(2);
         });
 
         it('formats falsy finite values', () => {
@@ -319,8 +342,12 @@ describe('format API', () => {
                 expect(() => formatRelative(0, {units: 'second'})).toNotThrow();
             });
 
-            it('throws on invalid IntlRelativeFormat options', () => {
-                expect(() => formatRelative(0, {units: 'invalid'})).toThrow();
+            it('fallsback and wanrs on invalid IntlRelativeFormat options', () => {
+                expect(formatRelative(0, {units: 'invalid'})).toBe(String(new Date(0)));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toBe(
+                    '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of: "second", "minute", "hour", "day", "month", "year"'
+                );
             });
 
             it('uses configured named formats', () => {
@@ -373,9 +400,10 @@ describe('format API', () => {
                     expect(formatRelative(1000)).toBe(rf.format(1000, {now}));
                 });
 
-                it('does not throw when a non-finite value is provided', () => {
+                it('does not throw or warn when a non-finite value is provided', () => {
                     expect(() => formatRelative(0, {now: NaN})).toNotThrow();
                     expect(() => formatRelative(0, {now: ''})).toNotThrow();
+                    expect(consoleError.calls.length).toBe(0);
                 });
 
                 it('formats falsy finite values', () => {
@@ -450,8 +478,12 @@ describe('format API', () => {
                 expect(() => formatNumber(0, {style: 'percent'})).toNotThrow();
             });
 
-            it('throws on invalid Intl.NumberFormat options', () => {
-                expect(() => formatNumber(0, {style: 'invalid'})).toThrow();
+            it('fallsback and warns on invalid Intl.NumberFormat options', () => {
+                expect(formatNumber(0, {style: 'invalid'})).toBe(String(0));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toContain(
+                    '[React Intl] Error formatting number.\nRangeError'
+                );
             });
 
             it('uses configured named formats', () => {


### PR DESCRIPTION
This wraps the number and date formatting calls in the format functions with a `try/catch` to prevent runtime errors. These functions will fallback and return the string value of the number or date `value`.