### PR TITLE
Revert commits that tmp fix Babel 6.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-cli": "^6.2.0",
     "babel-eslint": "^5.0.0-beta4",
     "babel-plugin-react-intl": "^2.0.0",
-    "babel-plugin-transform-es2015-block-scoping": "^6.6.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.4.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.3.13",
     "babel-plugin-transform-es3-property-literals": "^6.3.13",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -5,7 +5,6 @@
     ],
     "plugins": [
         "transform-object-rest-spread",
-        "transform-es2015-block-scoping",
         "transform-es3-member-expression-literals",
         "transform-es3-property-literals"
     ]


### PR DESCRIPTION
The latest release of Babel 6.6.x fixes the issue we were seeing with the tests, so these tmp-fix commits can now be reverted.