### PR TITLE
[IDEA] Move Intl constructor caches to module level

### DIFF
--- a/src/components/intl.js
+++ b/src/components/intl.js
@@ -28,6 +28,23 @@ const defaultProps = {
     defaultFormats: {},
 };
 
+// Creating `Intl*` formatters is expensive so these format caches memoize the
+// `Intl*` constructors.
+let memoizedIntlConstructors;
+const getMemoizedIntlConstructors = () => {
+    if (!memoizedIntlConstructors) {
+        memoizedIntlConstructors = {
+            getDateTimeFormat: memoizeIntlConstructor(Intl.DateTimeFormat),
+            getNumberFormat  : memoizeIntlConstructor(Intl.NumberFormat),
+            getMessageFormat : memoizeIntlConstructor(IntlMessageFormat),
+            getRelativeFormat: memoizeIntlConstructor(IntlRelativeFormat),
+            getPluralFormat  : memoizeIntlConstructor(IntlPluralFormat),
+        };
+    }
+
+    return memoizedIntlConstructors;
+};
+
 export default class IntlProvider extends Component {
     constructor(props, context) {
         super(props, context);
@@ -51,14 +68,7 @@ export default class IntlProvider extends Component {
         }
 
         this.state = {
-            // Creating `Intl*` formatters is expensive so these format caches
-            // memoize the `Intl*` constructors and have the same lifecycle as
-            // this IntlProvider instance.
-            getDateTimeFormat: memoizeIntlConstructor(Intl.DateTimeFormat),
-            getNumberFormat  : memoizeIntlConstructor(Intl.NumberFormat),
-            getMessageFormat : memoizeIntlConstructor(IntlMessageFormat),
-            getRelativeFormat: memoizeIntlConstructor(IntlRelativeFormat),
-            getPluralFormat  : memoizeIntlConstructor(IntlPluralFormat),
+            ...getMemoizedIntlConstructors(),
 
             // Wrapper to provide stable "now" time for initial render.
             now: () => {


### PR DESCRIPTION
This moves the `Intl*` constructor caches to the module level so they can be reused by all `<IntlProvider>` instances.

This will likely have a big impact on perf for the server, but comes at the cost of memory since this is basically a memory leak.