### PR TITLE
Use specific thresholds for relative formatting

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -5,6 +5,7 @@
  */
 
 import invariant from 'invariant';
+import IntlRelativeFormat from 'intl-relativeformat';
 
 import {
     dateTimeFormatPropTypes,
@@ -96,6 +97,17 @@ export function formatRelative(config, state, value, options = {}) {
     let defaults        = format && getNamedFormat(formats, 'relative', format);
     let filteredOptions = filterProps(options, RELATIVE_FORMAT_OPTIONS, defaults);
 
+    // Capture the current threshold values, then temporarily override them with
+    // specific values just for this render.
+    const thresholds = {...IntlRelativeFormat.thresholds};
+    Object.assign(IntlRelativeFormat.thresholds, {
+        second: 60, // seconds to minute
+        minute: 60, // minutes to hour
+        hour  : 24, // hours to day
+        day   : 30, // days to month
+        month : 12, // months to year
+    });
+
     try {
         return state.getRelativeFormat(locale, filteredOptions).format(date, {
             now: isFinite(now) ? now : state.now(),
@@ -106,6 +118,8 @@ export function formatRelative(config, state, value, options = {}) {
                 `[React Intl] Error formatting relative time.\n${e}`
             );
         }
+    } finally {
+        Object.assign(IntlRelativeFormat.thresholds, thresholds);
     }
 
     return String(date);

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -7,6 +7,7 @@ import * as f from '../../src/format';
 
 describe('format API', () => {
     const {NODE_ENV} = process.env;
+    const IRF_THRESHOLDS = {...IntlRelativeFormat.thresholds};
 
     let consoleError;
     let config;
@@ -331,6 +332,16 @@ describe('format API', () => {
         it('formats date ms timestamp values', () => {
             const timestamp = Date.now();
             expect(formatRelative(timestamp)).toBe(rf.format(timestamp, {now}));
+        });
+
+        it('formats with the expected thresholds', () => {
+            const timestamp = now - (1000 * 59);
+            expect(IntlRelativeFormat.thresholds).toEqual(IRF_THRESHOLDS);
+            expect(formatRelative(timestamp)).toNotBe(rf.format(timestamp, {now}));
+            expect(formatRelative(timestamp)).toBe('59 seconds ago');
+            expect(IntlRelativeFormat.thresholds).toEqual(IRF_THRESHOLDS);
+            expect(formatRelative(NaN)).toBe('Invalid Date');
+            expect(IntlRelativeFormat.thresholds).toEqual(IRF_THRESHOLDS);
         });
 
         describe('options', () => {


### PR DESCRIPTION
The `intl-relativeformat` package has a set of thresholds to round-up to the next significant unit that make sense for static formatting. But these thresholds don't make sense when `<FormattedRelative>` automatically "ticks" the relative times.

This change adjusts the thresholds to not round-up, and does so in a way that shouldn't effect other uses of `intl-relativeformat` because the thresholds are only temporarily updated, then put back after formatting.