### PR TITLE
Remove babel-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,18 @@
 {
-    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true,
+            "experimentalObjectRestSpread": true
+        }
+    },
     "extends": "eslint:recommended",
     "env": {
         "es6": true,
         "node": true,
         "browser": true,
         "mocha": true
-    },
-    "ecmaFeatures": {
-        "modules": true,
-        "jsx": true
     },
     "plugins": [
         "react"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",
-    "babel-eslint": "^6.0.0",
     "babel-plugin-react-intl": "^2.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.4.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.3.13",


### PR DESCRIPTION
`babel-eslint` released a patch version which caused the built to break. This removes `babel-eslint` because it's not currently needed.