### PR TITLE
Perf Improvements: shouldIntlComponentUpdate and nested IntlProviders

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -30,6 +30,7 @@ export const intlFormatPropTypes = {
 export const intlShape = shape({
     ...intlConfigPropTypes,
     ...intlFormatPropTypes,
+    formatters: object,
     now: func.isRequired,
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,10 +29,10 @@ export function escape(str) {
     return ('' + str).replace(UNSAFE_CHARS_REGEX, (match) => ESCAPED_CHARS[match]);
 }
 
-export function filterProps(obj, whitelist, defaults = {}) {
+export function filterProps(props, whitelist, defaults = {}) {
     return whitelist.reduce((filtered, name) => {
-        if (obj.hasOwnProperty(name)) {
-            filtered[name] = obj[name];
+        if (props.hasOwnProperty(name)) {
+            filtered[name] = props[name];
         } else if (defaults.hasOwnProperty(name)) {
             filtered[name] = defaults[name];
         }
@@ -86,9 +86,9 @@ export function shouldIntlComponentUpdate(
     return (
         !shallowEquals(nextProps, props) ||
         !shallowEquals(nextState, state) ||
-        !shallowEquals(
+        !(nextIntl === intl || shallowEquals(
             filterProps(nextIntl, intlConfigPropNames),
             filterProps(intl, intlConfigPropNames)
-        )
+        ))
     );
 }

--- a/test/perf/index.js
+++ b/test/perf/index.js
@@ -22,6 +22,23 @@ suite.on('error', function (e) {
     throw e.target.error;
 });
 
+const intlProvider = new IntlProvider({locale: 'en'}, {});
+
+suite.add('intlProvider.getChildContext()', function () {
+    intlProvider.getChildContext();
+});
+
+const intlProviderContext = intlProvider.getChildContext();
+const intlProvider2 = new IntlProvider({locale: 'en'}, intlProviderContext);
+
+suite.add('intlProvider.shouldComponentUpdate()', function () {
+    intlProvider2.shouldComponentUpdate(
+        {locale: 'en'},
+        intlProvider2.state,
+        intlProviderContext
+    );
+});
+
 suite.add('<div>', function () {
     ReactDOMServer.renderToString(
         <div />


### PR DESCRIPTION
Improved the perf of `shouldIntlComponentUpdate` util which now checks if `context.intl` is the same as `nextContext.intl` before doing a shallow compare of their filtered props.

Creating `Intl*` formatter instances is expensive, so `<IntlProvider>` memoizes the `Intl*` constructors to reuse the formatter instances. These memoized formatters are now shared with nested `<IntlProvider>` instances.

This sharing should increase the rendering perf of component architectures which use nested `<IntlProvider>` instances.