### PR TITLE
Extended the nested providers example for #419.

### DIFF
--- a/examples/nested/src/client/components/app.js
+++ b/examples/nested/src/client/components/app.js
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import {IntlProvider, FormattedMessage} from 'react-intl';
 import Greeting from './widgets/greeting';
+import Container from './widgets/container';
 
 class App extends Component {
     constructor(props) {
@@ -30,6 +31,11 @@ class App extends Component {
                 >
                     <Greeting {...this.state.user} />
                 </IntlProvider>
+
+                <Container
+                    getIntlMessages={this.props.getIntlMessages}
+                    app={<FormattedMessage id="app" defaultMessage={'App'} />}
+                />
             </div>
         );
     }

--- a/examples/nested/src/client/components/widgets/container.js
+++ b/examples/nested/src/client/components/widgets/container.js
@@ -1,0 +1,47 @@
+import React, {PropTypes} from 'react';
+import {IntlProvider, FormattedMessage} from 'react-intl';
+import Message from './message';
+
+const Container = ({getIntlMessages, app}) => (
+    <div>
+        <p>
+            <IntlProvider messages={getIntlMessages('container')}>
+                <FormattedMessage
+                    id="header"
+                    defaultMessage={'This is a container in '}
+                />
+            </IntlProvider>
+            {/* We don't know what app exactly is. It may be some element tree,
+                that may be wrapped in a provider or may use parent scope. */}
+            <b>{app}</b>
+            .
+        </p>
+        <p>
+            <IntlProvider messages={getIntlMessages('container')}>
+                <FormattedMessage
+                    id="intro"
+                    defaultMessage={'And it displays a message:'}
+                />
+            </IntlProvider>
+        </p>
+        <p>
+            {/* Could we wrap the whole message in container's provider?
+                No, as it may need access to the global message scope. */}
+            <Message getIntlMessages={getIntlMessages} app={app} container={
+                <IntlProvider messages={getIntlMessages('container')}>
+                    <FormattedMessage
+                        id="container"
+                        defaultMessage={'Container'}
+                    />
+                </IntlProvider>
+            } />
+        </p>
+    </div>
+);
+
+Container.propTypes = {
+    getIntlMessages: PropTypes.func.isRequired,
+    app: PropTypes.element.isRequired,
+};
+
+export default Container;

--- a/examples/nested/src/client/components/widgets/message.js
+++ b/examples/nested/src/client/components/widgets/message.js
@@ -1,0 +1,34 @@
+import React, {PropTypes} from 'react';
+import {IntlProvider, FormattedMessage} from 'react-intl';
+
+const Message = ({getIntlMessages, app, container}) => (
+    <i>
+        <IntlProvider messages={getIntlMessages('message')}>
+            <FormattedMessage
+                id="prefix"
+                defaultMessage={'This message is brought to you by '}
+            />
+        </IntlProvider>
+
+        <b>{app}</b>
+
+        <IntlProvider messages={getIntlMessages('message')}>
+            <FormattedMessage
+                id="infix"
+                defaultMessage={' via '}
+            />
+        </IntlProvider>
+
+        <b>{container}</b>
+
+        .
+    </i>
+);
+
+Message.propTypes = {
+    getIntlMessages: PropTypes.func.isRequired,
+    app: PropTypes.element.isRequired,
+    container: PropTypes.element.isRequired,
+};
+
+export default Message;


### PR DESCRIPTION
I've been trying to keep things simple and match the theme, so the example is somewhat artificial :-)
The `Container` and `Message` components could live in separate packages, and know little about namespaces defined or not defined in their parents (passing `getIntlMessages()` down seems to be a bit of unnecessary binding, and `getIntlFormats()` would also be needed). Containers within containers are not uncommon. The "strings" passed down could include some more complex content  (thus `FormattedHTMLMessage` could not be an option).

A more practical scenario would be for the container to be a modal with some textual chrome elements, and instead of a message it could display some canvas / svg chart that would include content passed down from the app.

Technically, we have all elements in a tree, so everything can be done with nested providers. Just wrap each message in the proper provider and pull common providers to ancestors in one way or another. On the other hand, namespaces can be used thoughtlessly and no binding between components needs to be introduced (each component can declare and use its own namespace -- just for its own messages).
