### PR TITLE
Add hoisting of static methods on components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "global:React"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^1.0.5",
     "intl-format-cache": "^2.0.5",
     "intl-messageformat": "^1.3.0",
     "intl-relativeformat": "^1.3.0",

--- a/src/inject.js
+++ b/src/inject.js
@@ -11,6 +11,7 @@ import React, {Component} from 'react';
 import invariant from 'invariant';
 import {intlShape} from './types';
 import {invariantIntlContext} from './utils';
+import hoistStatics from 'hoist-non-react-statics';
 
 function getDisplayName(Component) {
     return Component.displayName || Component.name || 'Component';
@@ -57,5 +58,5 @@ export default function injectIntl(WrappedComponent, options = {}) {
 
     InjectIntl.WrappedComponent = WrappedComponent;
 
-    return InjectIntl;
+    return hoistStatics(InjectIntl, WrappedComponent);
 }

--- a/test/unit/inject.js
+++ b/test/unit/inject.js
@@ -63,6 +63,18 @@ describe('injectIntl()', () => {
         expect(renderer.getRenderOutput()).toEqualJSX(<Wrapped foo="foo" intl={intl} />);
     });
 
+    it('hoists all static methods from <WrappedComponent>', () => {
+        class Wrapped extends React.Component {
+            static staticMethod() { return 'foo'; }
+            render() {
+                return <div />;
+            }
+        }
+
+        const Injected = injectIntl(Wrapped);
+        expect(Injected.staticMethod).toEqual(Wrapped.staticMethod);
+    });
+
     describe('options', () => {
         describe('intlPropName', () => {
             it('sets <WrappedComponent>\'s `props[intlPropName]` to `context.intl`', () => {


### PR DESCRIPTION
Making sure that a component with static methods will have those available after being wrapped with injectIntl.

I had a component with a static method that is used to create an `onEnter` hook in my react-router route definitions. After wrapping that component with `injectIntl` it no longer had that static method.

It was not a problem with react-redux's `connect` component, so I looked at how [it was implementing that](https://github.com/reactjs/react-redux/blob/ea53d6fb076359a864a1d543568d951d4b3eab3d/src/components/connect.js#L365) for reference.