### PR TITLE
FormattedMessage: Pass through DOM props. Closes #432

### DIFF
--- a/src/components/message.js
+++ b/src/components/message.js
@@ -109,7 +109,14 @@ export default class FormattedMessage extends Component {
             return children(...nodes);
         }
 
-        return createElement(tagName, null, ...nodes);
+        const props = { ...this.props };
+        delete props.id;
+        delete props.description;
+        delete props.defaultMessage;
+        delete props.values;
+        delete props.tagName;
+        delete props.children;
+        return createElement(tagName, props, ...nodes);
     }
 }
 

--- a/test/unit/components/message.js
+++ b/test/unit/components/message.js
@@ -153,6 +153,21 @@ describe('<FormattedMessage>', () => {
         );
     });
 
+    it('pass props to child component', () => {
+        const {intl} = intlProvider.getChildContext();
+        const descriptor = {
+            id: 'hello',
+            defaultMessage: 'Hello, World!',
+        };
+
+        const el = <FormattedMessage {...descriptor} tagName="a" href="?intl" className="css" />;
+
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <a href="?intl" className="css">{intl.formatMessage(descriptor)}</a>
+        );
+    });
+
     it('supports function-as-child pattern', () => {
         const {intl} = intlProvider.getChildContext();
         const descriptor = {


### PR DESCRIPTION
It allows you to write this JSX:
```jsx
<FormattedMessage {...descriptor} tagName="a" href="http://..." className="css" />
```
