### PR TITLE
Properly apply defaultProps to <IntlProvider>

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -79,10 +79,16 @@ export default class IntlProvider extends Component {
 
         // Build a whitelisted config object from `props`, defaults, and
         // `context.intl`, if an <IntlProvider> exists in the ancestry.
-        let config = {
-            ...defaultProps,
-            ...filterProps(this.props, intlConfigPropNames, intlContext),
-        };
+        let config = filterProps(this.props, intlConfigPropNames, intlContext);
+
+        // Apply default props. This must be applied last after the props have
+        // been resolved and inherited from any <IntlProvider> in the ancestry.
+        // This matches how React resolves `defaultProps`.
+        for (let propName in defaultProps) {
+            if (config[propName] === undefined) {
+                config[propName] = defaultProps[propName];
+            }
+        }
 
         if (!hasLocaleData(config.locale)) {
             const {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-
 /*
 HTML escaping and shallow-equals implementations are the same as React's
 (on purpose.) Therefore, it has the following Copyright and Licensing:

--- a/test/unit/components/intl.js
+++ b/test/unit/components/intl.js
@@ -183,6 +183,27 @@ describe('<IntlProvider>', () => {
         });
     });
 
+    it('provides `context.intl` with values from `defaultProps` for missing or undefined props', () => {
+        const props = {
+            locale: 'en-US',
+            defaultLocale: undefined,
+        };
+
+        const el = (
+            <IntlProvider {...props}>
+                <Child />
+            </IntlProvider>
+        );
+
+        renderer.render(el);
+        const {intl} = renderer.getMountedInstance().getChildContext();
+
+        expect(intl.defaultLocale).toNotBe(undefined);
+        expect(intl.defaultLocale).toBe('en');
+        expect(intl.messages).toNotBe(undefined);
+        expect(intl.messages).toBeAn('object');
+    });
+
     it('provides `context.intl` with format methods bound to intl config props', () => {
         const el = (
             <IntlProvider


### PR DESCRIPTION
Previously if a prop had an `undefined` value, it wouldn't receive the `defaultProps` value. This fixes that.

_Note: `<IntlProvider>` doesn't use React's built-in `defaultProps` resolution because it first inherits for an `<IntlProvider>` in its ancestry._