### PR TITLE
Fix <FormattedRelative> to update when value changes

### DIFF
--- a/src/components/relative.js
+++ b/src/components/relative.js
@@ -47,6 +47,17 @@ function getUnitDelay(units) {
     }
 }
 
+function isSameDate(a, b) {
+    if (a === b) {
+        return true;
+    }
+
+    let aTime = new Date(a).getTime();
+    let bTime = new Date(b).getTime();
+
+    return isFinite(aTime) && isFinite(bTime) && aTime === bTime;
+}
+
 export default class FormattedRelative extends Component {
     constructor(props, context) {
         super(props, context);
@@ -91,16 +102,24 @@ export default class FormattedRelative extends Component {
         }, delay);
     }
 
+    componentDidMount() {
+        this.scheduleNextUpdate(this.props, this.state);
+    }
+
+    componentWillReceiveProps({value: nextValue}) {
+        // When the `props.value` date changes, `state.now` needs to be updated,
+        // and the next update can be rescheduled.
+        if (!isSameDate(nextValue, this.props.value)) {
+            this.setState({now: this.context.intl.now()});
+        }
+    }
+
     shouldComponentUpdate(...next) {
         return shouldIntlComponentUpdate(this, ...next);
     }
 
     componentWillUpdate(nextProps, nextState) {
         this.scheduleNextUpdate(nextProps, nextState);
-    }
-
-    componentDidMount() {
-        this.scheduleNextUpdate(this.props, this.state);
     }
 
     componentWillUnmount() {

--- a/test/unit/components/relative.js
+++ b/test/unit/components/relative.js
@@ -210,6 +210,29 @@ describe('<FormattedRelative>', () => {
         }, 10);
     });
 
+    it('updates when the `value` prop changes', () => {
+        const {intl} = intlProvider.getChildContext();
+        const now = intl.now();
+
+        renderer.render(<FormattedRelative value={now} updateInterval={1} />, {intl});
+        const renderedOne = renderer.getRenderOutput();
+
+        // Shallow Renderer doesn't call `componentDidMount()`. This forces the
+        // scheduler to schedule an update based on the `updateInterval`.
+        renderer.getMountedInstance().componentDidMount();
+
+        // Update `now()` to act like the <IntlProvider> is mounted.
+        const nextNow = now + 1000;
+        intl.now = () => nextNow;
+
+        renderer.render(<FormattedRelative value={nextNow} updateInterval={1} />, {intl});
+        const renderedTwo = renderer.getRenderOutput();
+
+        expect(renderedTwo).toEqualJSX(renderedOne);
+
+        renderer.unmount();
+    });
+
     it('updates at maximum of `updateInterval` with a string `value`', (done) => {
         const {intl} = intlProvider.getChildContext();
 


### PR DESCRIPTION
This fixes the issue where `<FormattedRelative>` would render the incorrect relative time when its `props.value` was updated.

Fixes #495