### PR TITLE
The component passed to `injectIntl` should return a component with the same propTypes

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -55,6 +55,11 @@ export default function injectIntl(WrappedComponent, options = {}) {
         intl: intlShape,
     };
 
+    InjectIntl.propTypes = {
+        ...WrappedComponent.propTypes,
+        [intlPropName]: intlShape,
+    };
+
     InjectIntl.WrappedComponent = WrappedComponent;
 
     return InjectIntl;

--- a/test/unit/inject.js
+++ b/test/unit/inject.js
@@ -63,6 +63,20 @@ describe('injectIntl()', () => {
         expect(renderer.getRenderOutput()).toEqualJSX(<Wrapped foo="foo" intl={intl} />);
     });
 
+    it('adds all props from <WrappedComponent> to <InjectIntl>', () => {
+        Wrapped.propTypes = {
+            ...Wrapped.propTypes,
+            foo: React.PropTypes.string,
+            bar: React.PropTypes.string.isRequired,
+        };
+
+        const Injected = injectIntl(Wrapped);
+        const {intl} = intlProvider.getChildContext();
+
+        renderer.render(<Injected foo="foo" bar="bar" />, {intl});
+        expect(Injected.propTypes).toEqual(Wrapped.propTypes);
+    });
+
     describe('options', () => {
         describe('intlPropName', () => {
             it('sets <WrappedComponent>\'s `props[intlPropName]` to `context.intl`', () => {


### PR DESCRIPTION
I came across a scenario in which the propTypes were unavailable on the object returned by the `injectIntl` method. For example:

```
export class Rocket extends Component {
  ...
}

Rocket.propTypes = {
  fuel: PropTypes.string,
};

export default injectIntl(Rocket);
```
And then elsewhere:
```
import Rocket from './rocket';

export class Falcon extends Component {
  ...
}

Falcon.propTypes = {
  fuel: Rocket.propTypes.fuel, // Rocket.propTypes is `undefined`
  revision: PropTypes.number.isRequired,
};
```

I realize that they are available on the `WrappedComponent` property, but found this to be undesirable. 
```
Falcon.propTypes = {
  fuel: Rocket.WrappedComponent.propTypes.fuel,
  revision: PropTypes.number.isRequired,
};
```

Another solution was to access the `propTypes` on a named export, which also felt undesirable:
```
export Rocket, { Rocket as NamedRocket } from './rocket';

Falcon.propTypes = {
  fuel: NamedRocket.propTypes.fuel,
  revision: PropTypes.number.isRequired,
}
```

Passing my component to the `injectIntl` should enhance my component, but losing access to `propTypes` directly felt like a degradation to the component.

These proposed changes return a component whose propTypes match those that you originally defined on the component you are enhancing, and also attach the required prop defined by `intlPropName`.