### PR TITLE
Produce a nice error if a ReactElement is passed to formatMessage()

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -6,6 +6,7 @@
 
 import invariant from 'invariant';
 import IntlRelativeFormat from 'intl-relativeformat';
+import {isValidElement} from 'react';
 
 import {
     dateTimeFormatPropTypes,
@@ -189,6 +190,12 @@ export function formatMessage(config, state, messageDescriptor = {}, values = {}
         id,
         defaultMessage,
     } = messageDescriptor;
+
+    // Produce a better error if the user calls `intl.formatMessage(element)`
+    if (process.env.NODE_ENV !== 'production') {
+        invariant(!isValidElement(config), '[React Intl] Don\'t pass React elements to ' +
+            'formatMessage(), pass `.props`.');
+    }
 
     // `id` is a required field of a Message Descriptor.
     invariant(id, '[React Intl] An `id` must be provided to format a message.');


### PR DESCRIPTION
We monkey-patch this in our development environment. It's useful for e.g. reusing constant elements in multiple places in the code:

```jsx
const CommonMessages = {
  'Error': (<FormattedMessage 
    id="common.error" 
    description="Common error message."
    defaultMessage="Error" />)
};

// ...

render() {
  // should be passing `.props`, not the element - common mistake
  <span title={this.context.intl.formatMessage(CommonMessages['Error'])}>Error</span>
}
```

This produces the error `'[React Intl] An `id` must be provided to format a message.'` which could be more helpful.

This patch produces the error: `'[React Intl] Don\'t pass React elements to formatMessage(), pass `.props`.'` which is more descriptive.