### PR TITLE
Add module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "git@github.com:yahoo/react-intl.git"
   },
   "main": "./lib/index.js",
+  "module": "./lib/index.es.js",
   "jsnext:main": "./lib/index.es.js",
   "browser": {
     "./locale-data/index": false,


### PR DESCRIPTION
Closes https://github.com/yahoo/react-intl/issues/548

It's a bit beyond me to add a webpack 2 example right now. This just follows:

https://github.com/reactjs/react-router/pull/3672
https://github.com/reactjs/redux/pull/1871

And is enabled by default for Rollup now: https://github.com/rollup/rollup-plugin-node-resolve/pull/49