### PR TITLE
Add default values to formatTime

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -85,13 +85,9 @@ export function formatTime(config, state, value, options = {}) {
     let defaults        = format && getNamedFormat(formats, 'time', format);
     let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
 
-    // When no formatting options have been specified, default to outputting a
-    // time; e.g.: "9:42 AM".
-    if (Object.keys(filteredOptions).length === 0) {
-        filteredOptions = {
-            hour  : 'numeric',
-            minute: 'numeric',
-        };
+    if (!filteredOptions.hour && !filteredOptions.minute && !filteredOptions.second) {
+        // Add default formatting options if hour, minute, or second isn't defined.
+        filteredOptions = { ...filteredOptions, hour: 'numeric', minute: 'numeric'};
     }
 
     try {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -287,6 +287,38 @@ describe('format API', () => {
                     `[React Intl] No time format named: ${format}`
                 );
             });
+
+            it('should set default values', () => {
+                const date = new Date();
+                const {locale} = config;
+                const day = 'numeric';
+                df = new Intl.DateTimeFormat(locale, {hour: 'numeric', minute: 'numeric', day});
+                expect(formatTime(date, {day})).toBe(df.format(date));
+            });
+
+            it('should not set default values when second is provided', () => {
+                const date = new Date();
+                const {locale} = config;
+                const second = 'numeric';
+                df = new Intl.DateTimeFormat(locale, {second});
+                expect(formatTime(date, {second})).toBe(df.format(date));
+            });
+
+            it('should not set default values when minute is provided', () => {
+                const date = new Date();
+                const {locale} = config;
+                const minute = 'numeric';
+                df = new Intl.DateTimeFormat(locale, {minute});
+                expect(formatTime(date, {minute})).toBe(df.format(date));
+            });
+
+            it('should not set default values when hour is provided', () => {
+                const date = new Date();
+                const {locale} = config;
+                const hour = 'numeric';
+                df = new Intl.DateTimeFormat(locale, {hour});
+                expect(formatTime(date, {hour})).toBe(df.format(date));
+            });
         });
     });
 


### PR DESCRIPTION
Currently, when using `formatTime` and other date-format options, such as timeZone, `formatTime` acts as `formatDate`. This implies that the following (in Europe at 9:27 the 17. August 2016, CET):

```xml
<FormatTime value={someDate} />
<FormatTime value={someDate} timeZone='America/Los_Angeles' />
```

renders

```xml
<span>9:27 AM</span>
<span>8/17/2016</span>
```

which makes `FormatTime` useless.

This pull request supplies default values `{hour: 'numeric', minute: 'numeric'}` which will make the above example render

```xml
<span>9:27 AM</span>
<span>12:27 AM</span>
```