### PR TITLE
Fix unit tests for React 15.3.1 change

### DIFF
--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -85,9 +85,7 @@ describe('<IntlProvider>', () => {
     });
 
     it('throws when no `children`', () => {
-        expect(() => renderer.render(<IntlProvider />)).toThrow(
-            'onlyChild must be passed a children with exactly one child.'
-        );
+        expect(() => renderer.render(<IntlProvider />)).toThrow();
     });
 
     it('throws when more than one `children`', () => {
@@ -98,9 +96,7 @@ describe('<IntlProvider>', () => {
             </IntlProvider>
         );
 
-        expect(() => renderer.render(el)).toThrow(
-            'onlyChild must be passed a children with exactly one child.'
-        );
+        expect(() => renderer.render(el)).toThrow();
     });
 
     it('warns when no `locale` prop is provided', () => {


### PR DESCRIPTION
React changed the `React.Children.only()` error message: https://github.com/facebook/react/pull/7514

This updates the unit tests to not rely on testing for the exact message.