### PR TITLE
Add watch scripts to examples

### DIFF
--- a/examples/async/README.md
+++ b/examples/async/README.md
@@ -19,3 +19,10 @@ Then you can build and run this example:
 $ npm run build
 $ npm start
 ```
+
+or you can edit the source in `index.js` and recompile the example on fly :
+
+```
+$ npm run watch
+$ npm start
+```

--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf build",
     "build": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify index.js -d -t babelify -t browserify-shim > build/bundle.js",
+    "watch": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/watchify index.js -d -t babelify -t browserify-shim -o build/bundle.js -v",
     "start": "../../node_modules/.bin/babel-node server.js"
   },
   "author": "James Kyle <me@thejameskyle.com>",

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -19,3 +19,10 @@ Then you can run this example:
 $ npm run build
 $ npm start
 ```
+
+or you can edit the source in `index.js` and recompile the example on fly :
+
+```
+$ npm run watch
+$ npm start
+```

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf build",
     "build": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify index.js -d -t babelify -t browserify-shim > build/bundle.js",
+    "watch": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/watchify index.js -d -t babelify -t browserify-shim -o build/bundle.js -v",
     "start": "../../node_modules/.bin/babel-node server.js"
   },
   "author": "Eric Ferraiuolo <edf@ericf.me>",

--- a/examples/nested/README.md
+++ b/examples/nested/README.md
@@ -21,3 +21,10 @@ Then you can build and run this example:
 $ npm run build
 $ npm start
 ```
+
+or you can edit any source in `src/client/` and recompile the example on fly :
+
+```
+$ npm run watch
+$ npm start
+```

--- a/examples/nested/package.json
+++ b/examples/nested/package.json
@@ -9,6 +9,8 @@
     "build:bundle": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify src/client/index.js -d -t babelify -t browserify-shim > build/bundle.js",
     "build:group-messages": "../../node_modules/.bin/babel-node scripts/group-messages.js",
     "build": "npm run build:bundle && npm run build:group-messages",
+    "watch:bundle": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/watchify src/client/index.js -d -t babelify -t browserify-shim -o build/bundle.js -v",
+    "watch": "npm run build:group-messages && npm run watch:bundle",
     "start": "../../node_modules/.bin/babel-node src/server/index.js"
   },
   "author": "Eric Ferraiuolo <edf@ericf.me>",

--- a/examples/react-router/README.md
+++ b/examples/react-router/README.md
@@ -21,3 +21,10 @@ Then you can build and run this example:
 $ npm run build
 $ npm start
 ```
+
+or you can edit the source in `index.js` and recompile the example on the fly :
+
+```
+$ npm run watch
+$ npm start
+```

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf build",
     "build": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify index.js -d -t babelify -t browserify-shim > build/bundle.js",
+    "watch": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/watchify index.js -d -t babelify -t browserify-shim -o build/bundle.js -v",
     "start": "../../node_modules/.bin/babel-node server.js"
   },
   "author": "Eric Ferraiuolo <edf@ericf.me>",

--- a/examples/translations/README.md
+++ b/examples/translations/README.md
@@ -21,3 +21,10 @@ Then you can build and run this example:
 $ npm run build
 $ npm start
 ```
+
+or you can edit any source in `src/client` and recompile the example on the fly:
+
+```
+$ npm run watch
+$ npm start
+```

--- a/examples/translations/package.json
+++ b/examples/translations/package.json
@@ -9,6 +9,8 @@
     "build:bundle": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/browserify src/client/index.js -d -t babelify -t browserify-shim > build/bundle.js",
     "build:langs": "../../node_modules/.bin/babel-node scripts/translate.js",
     "build": "npm run build:bundle && npm run build:langs",
+    "watch:bundle": "../../node_modules/.bin/mkdirp build && ../../node_modules/.bin/watchify src/client/index.js -d -t babelify -t browserify-shim -o build/bundle.js -v",
+    "watch": "npm run build:langs && npm run watch:bundle",
     "start": "../../node_modules/.bin/babel-node src/server/index.js"
   },
   "author": "Eric Ferraiuolo <edf@ericf.me>",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "rollup-plugin-replace": "^1.1.0",
     "rollup-plugin-uglify": "^1.0.0",
     "serialize-javascript": "^1.1.1",
-    "superagent": "^2.0.0"
+    "superagent": "^2.0.0",
+    "watchify": "^3.7.0"
   },
   "scripts": {
     "clean": "rimraf src/en.js coverage/ dist/ lib/ locale-data/",


### PR DESCRIPTION
This adds `watch` scripts in examples, to recompile the build on the fly 💨 

Resolve #582 