### PR TITLE
Remove propTypes from production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-plugin-transform-es3-member-expression-literals": "^6.3.13",
     "babel-plugin-transform-es3-property-literals": "^6.3.13",
     "babel-plugin-transform-object-rest-spread": "^6.1.18",
+    "babel-plugin-transform-react-remove-prop-types": "^0.2.10",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-es2015-rollup": "^1.1.1",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -7,7 +7,8 @@
         "transform-object-rest-spread",
         "transform-class-properties",
         "transform-es3-member-expression-literals",
-        "transform-es3-property-literals"
+        "transform-es3-property-literals",
+        ["transform-react-remove-prop-types", {"mode": "wrap"}]
     ],
     "env": {
         "test": {

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,10 @@
 import {PropTypes} from 'react';
 
 const {bool, number, string, func, object, oneOf, shape} = PropTypes;
+const localeMatcher = oneOf(['best fit', 'lookup']);
+const narrowShortLong = oneOf(['narrow', 'short', 'long']);
+const numeric2digit = oneOf(['numeric', '2-digit']);
+const funcReq = func.isRequired;
 
 export const intlConfigPropTypes = {
     locale  : string,
@@ -18,20 +22,20 @@ export const intlConfigPropTypes = {
 };
 
 export const intlFormatPropTypes = {
-    formatDate       : func.isRequired,
-    formatTime       : func.isRequired,
-    formatRelative   : func.isRequired,
-    formatNumber     : func.isRequired,
-    formatPlural     : func.isRequired,
-    formatMessage    : func.isRequired,
-    formatHTMLMessage: func.isRequired,
+    formatDate       : funcReq,
+    formatTime       : funcReq,
+    formatRelative   : funcReq,
+    formatNumber     : funcReq,
+    formatPlural     : funcReq,
+    formatMessage    : funcReq,
+    formatHTMLMessage: funcReq,
 };
 
 export const intlShape = shape({
     ...intlConfigPropTypes,
     ...intlFormatPropTypes,
     formatters: object,
-    now: func.isRequired,
+    now: funcReq,
 });
 
 export const messageDescriptorPropTypes = {
@@ -41,25 +45,25 @@ export const messageDescriptorPropTypes = {
 };
 
 export const dateTimeFormatPropTypes = {
-    localeMatcher: oneOf(['best fit', 'lookup']),
+    localeMatcher,
     formatMatcher: oneOf(['basic', 'best fit']),
 
     timeZone: string,
     hour12  : bool,
 
-    weekday     : oneOf(['narrow', 'short', 'long']),
-    era         : oneOf(['narrow', 'short', 'long']),
-    year        : oneOf(['numeric', '2-digit']),
+    weekday     : narrowShortLong,
+    era         : narrowShortLong,
+    year        : numeric2digit,
     month       : oneOf(['numeric', '2-digit', 'narrow', 'short', 'long']),
-    day         : oneOf(['numeric', '2-digit']),
-    hour        : oneOf(['numeric', '2-digit']),
-    minute      : oneOf(['numeric', '2-digit']),
-    second      : oneOf(['numeric', '2-digit']),
+    day         : numeric2digit,
+    hour        : numeric2digit,
+    minute      : numeric2digit,
+    second      : numeric2digit,
     timeZoneName: oneOf(['short', 'long']),
 };
 
 export const numberFormatPropTypes = {
-    localeMatcher: oneOf(['best fit', 'lookup']),
+    localeMatcher,
 
     style          : oneOf(['decimal', 'currency', 'percent']),
     currency       : string,


### PR DESCRIPTION
Motivation
===
Removed propTypes from production builds, as they are unused by React in production and just take up extra bytes. This can reduce the minimized dist build by as much as **~3%!**:

```
// before
48170 Oct 19 11:21 react-intl.min.js

// after
46836 Oct 19 11:24 react-intl.min.js
```

What changed
===
For `lib/` builds, propTypes are wrapped in a conditional statement (`if(process.env.NODE_ENV !== 'production'){}`). This keeps the proptypes in place during development so that dev have access to them, but removes them when built with a packager (browserify/webpack/rollup/etc) that replaces `process.env.NODE_ENV` with the actual value.

For `dist/` build, the process is similar, but when `isProduction == true`, the propTypes will be completely removed. It was necessary to move the `replace()` plugin to the `isProduction == true` build so that propTypes aren't completely removed for non production build.

Finally, due to the non-standard way of how propTypes are defined in this project, the definitions themselves were manually wrapped where possible (see below). This, again, keeps them in development build but removes them for production builds.

TODO:
===
It seems some proptypes are used by the code during runtime for non-propType related activity. Can these be updated/removed/otherwise minified for even more saving?

Disclaimer
===
I hope I didn't misunderstand how the build process works!

Prior art:
===
 * react-virtualized: https://github.com/bvaughn/react-virtualized/pull/438 & https://github.com/bvaughn/react-virtualized/pull/440
 * react-router: https://github.com/ReactTraining/react-router/issues/4046
 * react: https://github.com/facebook/react/pull/7651, https://github.com/facebook/react/pull/2948, amongst others
 * the plugin: https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types

Related:
===
This is a first step towards https://github.com/yahoo/react-intl/issues/687
