### PR TITLE
Use defaultFormats in formatNumber, formatDate, formatTime and formatRelative

### DIFF
--- a/examples/default-formats/.gitignore
+++ b/examples/default-formats/.gitignore
@@ -1,0 +1,15 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+
+# testing
+coverage
+
+# production
+build
+
+# misc
+.DS_Store
+.env
+npm-debug.log

--- a/examples/default-formats/README.md
+++ b/examples/default-formats/README.md
@@ -1,0 +1,13 @@
+React Intl Default Formats Example
+==============================
+
+This app shows how to use defaultFormats in React Intl to specify default formats for dates and times.
+
+## Running Example
+
+**In the project directory, run:**
+```
+$ npm install
+$ npm start
+```
+**Open [http://localhost:3000](http://localhost:3000) to view it in the browser.**

--- a/examples/default-formats/package.json
+++ b/examples/default-formats/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-intl-example-default-formats-example",
+  "version": "1.0.0",
+  "description": "React Intl Default Formats Example",
+  "private": true,
+  "main": "index.js",
+  "author": "Bryan Richards <brichardssa@gmail.com>",
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "react-scripts": "0.6.0"
+  },
+  "dependencies": {
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "react-intl": "file:../../"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/examples/default-formats/public/index.html
+++ b/examples/default-formats/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>React Intl Default Formats Example</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=Intl.~locale.en"></script>
+    </body>
+</html>

--- a/examples/default-formats/src/App.js
+++ b/examples/default-formats/src/App.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import {FormattedTime} from 'react-intl';
+
+export default () => {
+    const currentTime = new Date();
+
+    return <p>The time in Tokyo is: <FormattedTime value={currentTime} /></p>;
+};

--- a/examples/default-formats/src/index.js
+++ b/examples/default-formats/src/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {IntlProvider} from 'react-intl';
+import App from './App';
+
+ReactDOM.render(
+    <IntlProvider locale="en" defaultFormats={{
+        time: {
+            timeZone: 'Asia/Tokyo'
+        }
+    }}>
+        <App />
+    </IntlProvider>,
+    document.getElementById('root')
+);

--- a/examples/default-formats/src/index.js
+++ b/examples/default-formats/src/index.js
@@ -6,8 +6,8 @@ import App from './App';
 ReactDOM.render(
     <IntlProvider locale="en" defaultFormats={{
         time: {
-            timeZone: 'Asia/Tokyo'
-        }
+            timeZone: 'Asia/Tokyo',
+        },
     }}>
         <App />
     </IntlProvider>,

--- a/src/format.js
+++ b/src/format.js
@@ -57,13 +57,12 @@ function getNamedFormat(formats, type, name) {
 }
 
 export function formatDate(config, state, value, options = {}) {
-    const {locale, formats} = config;
+    const {locale, defaultFormats, formats} = config;
     const {format}          = options;
 
     let date            = new Date(value);
-    let defaults        = format && getNamedFormat(formats, 'date', format);
+    let defaults        = format ? getNamedFormat(formats, 'date', format) : defaultFormats.date;
     let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
-
     try {
         return state.getDateTimeFormat(locale, filteredOptions).format(date);
     } catch (e) {

--- a/src/format.js
+++ b/src/format.js
@@ -104,12 +104,12 @@ export function formatTime(config, state, value, options = {}) {
 }
 
 export function formatRelative(config, state, value, options = {}) {
-    const {locale, formats} = config;
+    const {locale, defaultFormats, formats} = config;
     const {format}          = options;
 
     let date            = new Date(value);
     let now             = new Date(options.now);
-    let defaults        = format && getNamedFormat(formats, 'relative', format);
+    let defaults        = format ? getNamedFormat(formats, 'relative', format) : defaultFormats.relative;
     let filteredOptions = filterProps(options, RELATIVE_FORMAT_OPTIONS, defaults);
 
     // Capture the current threshold values, then temporarily override them with

--- a/src/format.js
+++ b/src/format.js
@@ -63,6 +63,7 @@ export function formatDate(config, state, value, options = {}) {
     let date            = new Date(value);
     let defaults        = format ? getNamedFormat(formats, 'date', format) : defaultFormats.date;
     let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
+
     try {
         return state.getDateTimeFormat(locale, filteredOptions).format(date);
     } catch (e) {
@@ -77,11 +78,11 @@ export function formatDate(config, state, value, options = {}) {
 }
 
 export function formatTime(config, state, value, options = {}) {
-    const {locale, formats} = config;
+    const {locale, defaultFormats, formats} = config;
     const {format}          = options;
 
     let date            = new Date(value);
-    let defaults        = format && getNamedFormat(formats, 'time', format);
+    let defaults        = format ? getNamedFormat(formats, 'time', format) : defaultFormats.time;
     let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
 
     if (!filteredOptions.hour && !filteredOptions.minute && !filteredOptions.second) {

--- a/src/format.js
+++ b/src/format.js
@@ -135,10 +135,10 @@ export function formatRelative(config, state, value, options = {}) {
 }
 
 export function formatNumber(config, state, value, options = {}) {
-    const {locale, formats} = config;
+    const {locale, defaultFormats, formats} = config;
     const {format}          = options;
 
-    let defaults        = format && getNamedFormat(formats, 'number', format);
+    let defaults        = format ? getNamedFormat(formats, 'number', format) : defaultFormats.number;
     let filteredOptions = filterProps(options, NUMBER_FORMAT_OPTIONS, defaults);
 
     try {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -724,6 +724,61 @@ describe('format API', () => {
                 );
             });
         });
+
+        describe('defaultFormats', () => {
+            let numberDefaultFormats;
+
+            beforeEach(() => {
+                numberDefaultFormats = {
+                    style: 'percent'
+                };
+                nf = new Intl.NumberFormat(config.locale, numberDefaultFormats);
+                config.defaultFormats.number = numberDefaultFormats
+            });
+
+            it('uses defaultFormats when specified', () => {
+                expect(formatNumber(84)).toBe(nf.format(84));
+            });
+
+            it('is replaced when options are explicitly passed', () => {
+                let currencyNF = new Intl.NumberFormat(config.locale, {
+                    style: 'currency',
+                    currency: 'USD'
+                });
+                expect(formatNumber(31, {
+                    style: 'currency',
+                    currency: 'USD'
+                })).toBe(currencyNF.format(31));
+                expect(formatNumber(13, {
+                    style: 'currency',
+                    currency: 'USD'
+                })).toNotBe(nf.format(0));
+            });
+
+            it('accepts valid Intl.NumberFormat options', () => {
+                numberDefaultFormats.minimumIntegerDigits = 10;
+                expect(() => formatNumber(0)).toNotThrow();
+            });
+
+            it('fallsback and warns on invalid Intl.NumberFormat options', () => {
+                numberDefaultFormats.minimumIntegerDigits = 33;
+                expect(formatNumber(56)).toBe('56');
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toContain(
+                    '[React Intl] Error formatting number.\nRangeError'
+                );
+            });
+
+            it('uses configured named formats over defaultFormats', () => {
+                const number = 73.452;
+                const format = 'decimals';
+
+                const {locale, formats} = config;
+                nf = new Intl.NumberFormat(locale, formats.number[format]);
+
+                expect(formatNumber(number, {format})).toBe(nf.format(number));
+            });
+        });
     });
 
     describe('formatPlural()', () => {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -372,6 +372,60 @@ describe('format API', () => {
                 expect(formatTime(date, {hour})).toBe(df.format(date));
             });
         });
+
+        describe('defaultFormats', () => {
+            let timeDefaultFormats;
+
+            beforeEach(() => {
+                timeDefaultFormats = {
+                    timeZone: 'Pacific/Wake'
+                };
+                df = new Intl.DateTimeFormat(config.locale, {...timeDefaultFormats, hour: 'numeric', minute: 'numeric' });
+                config.defaultFormats.time = timeDefaultFormats
+            });
+
+            it('uses defaultFormats when specified', () => {
+                expect(formatTime(0)).toBe(df.format(0));
+            });
+
+            it('is replaced when options are explicitly passed', () => {
+                let johannesburgDF = new Intl.DateTimeFormat(config.locale, {
+                    timeZone: 'Africa/Johannesburg',
+                    hour: 'numeric',
+                    minute: 'numeric'
+                });
+                expect(formatTime(0, {
+                    timeZone: 'Africa/Johannesburg'
+                })).toBe(johannesburgDF.format(0));
+                expect(formatTime(0, {
+                    timeZone: 'Africa/Johannesburg'
+                })).toNotBe(df.format(0));
+            });
+
+            it('accepts valid Intl.DateTimeFormat options', () => {
+                timeDefaultFormats.hour = 'numeric';
+                expect(() => formatTime(0)).toNotThrow();
+            });
+
+            it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
+                timeDefaultFormats.hour = 'invalid';
+                expect(formatTime(0)).toBe(String(new Date(0)));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toContain(
+                    '[React Intl] Error formatting time.\nRangeError'
+                );
+            });
+
+            it('uses configured named formats over defaultFormats', () => {
+                const date   = new Date();
+                const format = 'hour-only';
+
+                const {locale, formats} = config;
+                df = new Intl.DateTimeFormat(locale, formats.time[format]);
+
+                expect(formatTime(date, {format})).toBe(df.format(date));
+            });
+        });
     });
 
     describe('formatRelative()', () => {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -385,7 +385,7 @@ describe('format API', () => {
                 expect(() => formatRelative(0, {units: 'second'})).toNotThrow();
             });
 
-            it('fallsback and wanrs on invalid IntlRelativeFormat options', () => {
+            it('fallsback and warns on invalid IntlRelativeFormat options', () => {
                 expect(formatRelative(0, {units: 'invalid'})).toBe(String(new Date(0)));
                 expect(consoleError.calls.length).toBe(1);
                 expect(consoleError.calls[0].arguments[0]).toBe(

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -578,6 +578,58 @@ describe('format API', () => {
                 });
             });
         });
+
+        describe('defaultFormats', () => {
+            let relativeDefaultFormats;
+
+            beforeEach(() => {
+                relativeDefaultFormats = {
+                    units: 'second'
+                };
+                rf = new IntlRelativeFormat(config.locale, relativeDefaultFormats);
+                config.defaultFormats.relative = relativeDefaultFormats
+            });
+
+            it('uses defaultFormats when specified', () => {
+                expect(formatRelative(0)).toBe(rf.format(0, {now}));
+            });
+
+            it('is replaced when options are explicitly passed', () => {
+                let hourRF = new IntlRelativeFormat(config.locale, {
+                    units: 'hour'
+                });
+                expect(formatRelative(0, {
+                    units: 'hour'
+                })).toBe(hourRF.format(0, {now}));
+                expect(formatRelative(0, {
+                    units: 'hour'
+                })).toNotBe(rf.format(0, {now}));
+            });
+
+            it('accepts valid IntlRelativeFormat options', () => {
+                relativeDefaultFormats.units = 'day';
+                expect(() => formatRelative(0)).toNotThrow();
+            });
+
+            it('fallsback and warns on invalid IntlRelativeFormat options', () => {
+                relativeDefaultFormats.units = 'invalid';
+                expect(formatRelative(0)).toBe(String(new Date(0)));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toBe(
+                    '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of: "second", "minute", "hour", "day", "month", "year"'
+                );
+            });
+
+            it('uses configured named formats over defaultFormats', () => {
+                const date   = -(1000 * 120);
+                const format = 'hours';
+
+                const {locale, formats} = config;
+                rf = new IntlRelativeFormat(locale, formats.relative[format]);
+
+                expect(formatRelative(date, {format})).toBe(rf.format(date, {now}));
+            });
+        });
     });
 
     describe('formatNumber()', () => {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -188,6 +188,58 @@ describe('format API', () => {
                 );
             });
         });
+
+        describe('defaultFormats', () => {
+            let dateDefaultFormats;
+
+            beforeEach(() => {
+                dateDefaultFormats = {
+                    era: 'narrow'
+                };
+                df = new Intl.DateTimeFormat(config.locale, dateDefaultFormats);
+                config.defaultFormats.date = dateDefaultFormats
+            });
+
+            it('uses defaultFormats when specified', () => {
+                expect(formatDate(0)).toBe(df.format(0));
+            });
+
+            it('is replaced when options are explicitly passed', () => {
+                let longEraDF = new Intl.DateTimeFormat(config.locale, {
+                    era: 'long'
+                });
+                expect(formatDate(0, {
+                    era: 'long'
+                })).toBe(longEraDF.format(0));
+                expect(formatDate(0, {
+                    era: 'long'
+                })).toNotBe(df.format(0));
+            });
+
+            it('accepts valid Intl.DateTimeFormat options', () => {
+                dateDefaultFormats.year = 'numeric';
+                expect(() => formatDate(0)).toNotThrow();
+            });
+
+            it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
+                dateDefaultFormats.year = 'invalid';
+                expect(formatDate(0)).toBe(String(new Date(0)));
+                expect(consoleError.calls.length).toBe(1);
+                expect(consoleError.calls[0].arguments[0]).toContain(
+                    '[React Intl] Error formatting date.\nRangeError'
+                );
+            });
+
+            it('uses configured named formats over defaultFormats', () => {
+                const date   = new Date();
+                const format = 'year-only';
+
+                const {locale, formats} = config;
+                df = new Intl.DateTimeFormat(locale, formats.date[format]);
+
+                expect(formatDate(date, {format})).toBe(df.format(date));
+            });
+        });
     });
 
     describe('formatTime()', () => {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -194,10 +194,10 @@ describe('format API', () => {
 
             beforeEach(() => {
                 dateDefaultFormats = {
-                    era: 'narrow'
+                    era: 'narrow',
                 };
                 df = new Intl.DateTimeFormat(config.locale, dateDefaultFormats);
-                config.defaultFormats.date = dateDefaultFormats
+                config.defaultFormats.date = dateDefaultFormats;
             });
 
             it('uses defaultFormats when specified', () => {
@@ -206,13 +206,13 @@ describe('format API', () => {
 
             it('is replaced when options are explicitly passed', () => {
                 let longEraDF = new Intl.DateTimeFormat(config.locale, {
-                    era: 'long'
+                    era: 'long',
                 });
                 expect(formatDate(0, {
-                    era: 'long'
+                    era: 'long',
                 })).toBe(longEraDF.format(0));
                 expect(formatDate(0, {
-                    era: 'long'
+                    era: 'long',
                 })).toNotBe(df.format(0));
             });
 
@@ -378,10 +378,10 @@ describe('format API', () => {
 
             beforeEach(() => {
                 timeDefaultFormats = {
-                    timeZone: 'Pacific/Wake'
+                    timeZone: 'Pacific/Wake',
                 };
                 df = new Intl.DateTimeFormat(config.locale, {...timeDefaultFormats, hour: 'numeric', minute: 'numeric' });
-                config.defaultFormats.time = timeDefaultFormats
+                config.defaultFormats.time = timeDefaultFormats;
             });
 
             it('uses defaultFormats when specified', () => {
@@ -392,13 +392,13 @@ describe('format API', () => {
                 let johannesburgDF = new Intl.DateTimeFormat(config.locale, {
                     timeZone: 'Africa/Johannesburg',
                     hour: 'numeric',
-                    minute: 'numeric'
+                    minute: 'numeric',
                 });
                 expect(formatTime(0, {
-                    timeZone: 'Africa/Johannesburg'
+                    timeZone: 'Africa/Johannesburg',
                 })).toBe(johannesburgDF.format(0));
                 expect(formatTime(0, {
-                    timeZone: 'Africa/Johannesburg'
+                    timeZone: 'Africa/Johannesburg',
                 })).toNotBe(df.format(0));
             });
 
@@ -584,10 +584,10 @@ describe('format API', () => {
 
             beforeEach(() => {
                 relativeDefaultFormats = {
-                    units: 'second'
+                    units: 'second',
                 };
                 rf = new IntlRelativeFormat(config.locale, relativeDefaultFormats);
-                config.defaultFormats.relative = relativeDefaultFormats
+                config.defaultFormats.relative = relativeDefaultFormats;
             });
 
             it('uses defaultFormats when specified', () => {
@@ -596,13 +596,13 @@ describe('format API', () => {
 
             it('is replaced when options are explicitly passed', () => {
                 let hourRF = new IntlRelativeFormat(config.locale, {
-                    units: 'hour'
+                    units: 'hour',
                 });
                 expect(formatRelative(0, {
-                    units: 'hour'
+                    units: 'hour',
                 })).toBe(hourRF.format(0, {now}));
                 expect(formatRelative(0, {
-                    units: 'hour'
+                    units: 'hour',
                 })).toNotBe(rf.format(0, {now}));
             });
 
@@ -730,10 +730,10 @@ describe('format API', () => {
 
             beforeEach(() => {
                 numberDefaultFormats = {
-                    style: 'percent'
+                    style: 'percent',
                 };
                 nf = new Intl.NumberFormat(config.locale, numberDefaultFormats);
-                config.defaultFormats.number = numberDefaultFormats
+                config.defaultFormats.number = numberDefaultFormats;
             });
 
             it('uses defaultFormats when specified', () => {
@@ -743,15 +743,15 @@ describe('format API', () => {
             it('is replaced when options are explicitly passed', () => {
                 let currencyNF = new Intl.NumberFormat(config.locale, {
                     style: 'currency',
-                    currency: 'USD'
+                    currency: 'USD',
                 });
                 expect(formatNumber(31, {
                     style: 'currency',
-                    currency: 'USD'
+                    currency: 'USD',
                 })).toBe(currencyNF.format(31));
                 expect(formatNumber(13, {
                     style: 'currency',
-                    currency: 'USD'
+                    currency: 'USD',
                 })).toNotBe(nf.format(0));
             });
 


### PR DESCRIPTION
resolve #702 

There may be times when default format options for numbers, dates and times need to be set explicitly by passing them to IntlProvider via props.

Added default-format example to demonstrate new functionality
