### PR TITLE
default `context` to empty object

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -45,7 +45,7 @@ export default class IntlProvider extends Component {
         initialNow: PropTypes.any,
     };
 
-    constructor(props, context) {
+    constructor(props, context = {}) {
         super(props, context);
 
         invariant(typeof Intl !== 'undefined',


### PR DESCRIPTION
Using `inferno`/`preact` if `IntlProvider` is the top component, `context` does not get populated