### PR TITLE
Fix failed prop type warnings on React Native

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -6,7 +6,7 @@
 
 import {PropTypes} from 'react';
 
-const {bool, number, string, func, object, oneOf, shape, node} = PropTypes;
+const {bool, number, string, func, object, oneOf, shape, any} = PropTypes;
 const localeMatcher = oneOf(['best fit', 'lookup']);
 const narrowShortLong = oneOf(['narrow', 'short', 'long']);
 const numeric2digit = oneOf(['numeric', '2-digit']);
@@ -16,7 +16,7 @@ export const intlConfigPropTypes = {
     locale       : string,
     formats      : object,
     messages     : object,
-    textComponent: node,
+    textComponent: any,
 
     defaultLocale : string,
     defaultFormats: object,


### PR DESCRIPTION
Using `react-intl@2.2.0` with React Native as documented (with `<IntlProvider textComponent={Text} ...>`) shows a prop type warning: "Warning: Failed prop type: Invalid prop `textComponent` supplied to `IntlProvider`"

The reason is that `Text` is not `node` but a component class. The correct `propType` for `textComponent` is "React component/function/class", but since this prop type doesn't exist, loosen it to `any`.

<img width="320" src="https://cloud.githubusercontent.com/assets/497214/21468764/444acdea-ca2e-11e6-982c-3ca1e21d5783.png"><img width="320" src="https://cloud.githubusercontent.com/assets/497214/21468765/444d5858-ca2e-11e6-9de2-35453c6d9833.png">
