### PR TITLE
Exporting hasLocaleData outside of library

### DIFF
--- a/src/react-intl.js
+++ b/src/react-intl.js
@@ -5,11 +5,11 @@
  */
 
 import defaultLocaleData from './en';
-import {addLocaleData} from './locale-data-registry';
+import {addLocaleData, hasLocaleData} from './locale-data-registry';
 
 addLocaleData(defaultLocaleData);
 
-export {addLocaleData};
+export {addLocaleData, hasLocaleData};
 export {intlShape} from './types';
 export {default as injectIntl} from './inject';
 export {default as defineMessages} from './define-messages';

--- a/test/unit/react-intl.js
+++ b/test/unit/react-intl.js
@@ -6,6 +6,10 @@ describe('react-intl', () => {
         it('exports `addLocaleData`', () => {
             expect(ReactIntl.addLocaleData).toBeA('function');
         });
+        
+        it('exports `hasLocaleData`', () => {
+            expect(ReactIntl.hasLocaleData).toBeA('function');
+        });
 
         it('exports `defineMessages`', () => {
             expect(ReactIntl.defineMessages).toBeA('function');


### PR DESCRIPTION
This will allow calling code to use hasLocaleData to see if the locale is supported. For instance if they have only loaded "en" but the browser reports "en-US" it prevents the user calling the same split and loop commands