### PR TITLE
613 custom error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ lib/
 locale-data/
 node_modules/
 src/en.js
+
+# IntelliJ
+.idea/

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -11,7 +11,12 @@ import IntlRelativeFormat from 'intl-relativeformat';
 import IntlPluralFormat from '../plural';
 import memoizeIntlConstructor from 'intl-format-cache';
 import invariant from 'invariant';
-import {shouldIntlComponentUpdate, filterProps} from '../utils';
+import {
+  createError,
+  defaultErrorHandler,
+  shouldIntlComponentUpdate,
+  filterProps,
+} from '../utils';
 import {intlConfigPropTypes, intlFormatPropTypes, intlShape} from '../types';
 import * as format from '../format';
 import {hasLocaleData} from '../locale-data-registry';
@@ -29,6 +34,8 @@ const defaultProps = {
 
   defaultLocale: 'en',
   defaultFormats: {},
+
+  onError: defaultErrorHandler,
 };
 
 export default class IntlProvider extends Component {
@@ -84,7 +91,8 @@ export default class IntlProvider extends Component {
         getRelativeFormat: memoizeIntlConstructor(IntlRelativeFormat),
         getPluralFormat: memoizeIntlConstructor(IntlPluralFormat),
       },
-    } = intlContext || {};
+    } =
+      intlContext || {};
 
     this.state = {
       ...formatters,
@@ -113,14 +121,14 @@ export default class IntlProvider extends Component {
     }
 
     if (!hasLocaleData(config.locale)) {
-      const {locale, defaultLocale, defaultFormats} = config;
+      const {locale, defaultLocale, defaultFormats, onError} = config;
 
-      if (process.env.NODE_ENV !== 'production') {
-        console.error(
-          `[React Intl] Missing locale data for locale: "${locale}". ` +
+      onError(
+        createError(
+          `Missing locale data for locale: "${locale}". ` +
             `Using default locale: "${defaultLocale}" as fallback.`
-        );
-      }
+        )
+      );
 
       // Since there's no registered locale data for `locale`, this will
       // fallback to the `defaultLocale` to make sure things can render.

--- a/src/format.js
+++ b/src/format.js
@@ -14,7 +14,7 @@ import {
   pluralFormatPropTypes,
 } from './types';
 
-import {escape, filterProps} from './utils';
+import {createError, defaultErrorHandler, escape, filterProps} from './utils';
 
 const DATE_TIME_FORMAT_OPTIONS = Object.keys(dateTimeFormatPropTypes);
 const NUMBER_FORMAT_OPTIONS = Object.keys(numberFormatPropTypes);
@@ -45,25 +45,24 @@ function updateRelativeFormatThresholds(newThresholds) {
   } = newThresholds);
 }
 
-function getNamedFormat(formats, type, name) {
+function getNamedFormat(formats, type, name, onError) {
   let format = formats && formats[type] && formats[type][name];
   if (format) {
     return format;
   }
 
-  if (process.env.NODE_ENV !== 'production') {
-    console.error(`[React Intl] No ${type} format named: ${name}`);
-  }
+  onError(createError(`No ${type} format named: ${name}`));
 }
 
 export function formatDate(config, state, value, options = {}) {
   const {locale, formats, timeZone} = config;
   const {format} = options;
 
+  let onError = config.onError || defaultErrorHandler;
   let date = new Date(value);
   let defaults = {
     ...(timeZone && {timeZone}),
-    ...(format && getNamedFormat(formats, 'date', format)),
+    ...(format && getNamedFormat(formats, 'date', format, onError)),
   };
   let filteredOptions = filterProps(
     options,
@@ -74,9 +73,7 @@ export function formatDate(config, state, value, options = {}) {
   try {
     return state.getDateTimeFormat(locale, filteredOptions).format(date);
   } catch (e) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting date.\n${e}`);
-    }
+    onError(createError('Error formatting date.', e));
   }
 
   return String(date);
@@ -86,10 +83,11 @@ export function formatTime(config, state, value, options = {}) {
   const {locale, formats, timeZone} = config;
   const {format} = options;
 
+  let onError = config.onError || defaultErrorHandler;
   let date = new Date(value);
   let defaults = {
     ...(timeZone && {timeZone}),
-    ...(format && getNamedFormat(formats, 'time', format)),
+    ...(format && getNamedFormat(formats, 'time', format, onError)),
   };
   let filteredOptions = filterProps(
     options,
@@ -109,9 +107,7 @@ export function formatTime(config, state, value, options = {}) {
   try {
     return state.getDateTimeFormat(locale, filteredOptions).format(date);
   } catch (e) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting time.\n${e}`);
-    }
+    onError(createError('Error formatting time.', e));
   }
 
   return String(date);
@@ -121,9 +117,10 @@ export function formatRelative(config, state, value, options = {}) {
   const {locale, formats} = config;
   const {format} = options;
 
+  let onError = config.onError || defaultErrorHandler;
   let date = new Date(value);
   let now = new Date(options.now);
-  let defaults = format && getNamedFormat(formats, 'relative', format);
+  let defaults = format && getNamedFormat(formats, 'relative', format, onError);
   let filteredOptions = filterProps(options, RELATIVE_FORMAT_OPTIONS, defaults);
 
   // Capture the current threshold values, then temporarily override them with
@@ -136,9 +133,7 @@ export function formatRelative(config, state, value, options = {}) {
       now: isFinite(now) ? now : state.now(),
     });
   } catch (e) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting relative time.\n${e}`);
-    }
+    onError(createError('Error formatting relative time.', e));
   } finally {
     updateRelativeFormatThresholds(oldThresholds);
   }
@@ -150,15 +145,14 @@ export function formatNumber(config, state, value, options = {}) {
   const {locale, formats} = config;
   const {format} = options;
 
-  let defaults = format && getNamedFormat(formats, 'number', format);
+  let onError = config.onError || defaultErrorHandler;
+  let defaults = format && getNamedFormat(formats, 'number', format, onError);
   let filteredOptions = filterProps(options, NUMBER_FORMAT_OPTIONS, defaults);
 
   try {
     return state.getNumberFormat(locale, filteredOptions).format(value);
   } catch (e) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting number.\n${e}`);
-    }
+    onError(createError('Error formatting number.', e));
   }
 
   return String(value);
@@ -168,13 +162,12 @@ export function formatPlural(config, state, value, options = {}) {
   const {locale} = config;
 
   let filteredOptions = filterProps(options, PLURAL_FORMAT_OPTIONS);
+  let onError = config.onError || defaultErrorHandler;
 
   try {
     return state.getPluralFormat(locale, filteredOptions).format(value);
   } catch (e) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting plural.\n${e}`);
-    }
+    onError(createError('Error formatting plural.', e));
   }
 
   return 'other';
@@ -203,6 +196,7 @@ export function formatMessage(
   }
 
   let formattedMessage;
+  let onError = config.onError || defaultErrorHandler;
 
   if (message) {
     try {
@@ -210,28 +204,28 @@ export function formatMessage(
 
       formattedMessage = formatter.format(values);
     } catch (e) {
-      if (process.env.NODE_ENV !== 'production') {
-        console.error(
-          `[React Intl] Error formatting message: "${id}" for locale: "${locale}"` +
-            (defaultMessage ? ', using default message as fallback.' : '') +
-            `\n${e}`
-        );
-      }
+      onError(
+        createError(
+          `Error formatting message: "${id}" for locale: "${locale}"` +
+            (defaultMessage ? ', using default message as fallback.' : ''),
+          e
+        )
+      );
     }
   } else {
-    if (process.env.NODE_ENV !== 'production') {
-      // This prevents warnings from littering the console in development
-      // when no `messages` are passed into the <IntlProvider> for the
-      // default locale, and a default message is in the source.
-      if (
-        !defaultMessage ||
-        (locale && locale.toLowerCase() !== defaultLocale.toLowerCase())
-      ) {
-        console.error(
-          `[React Intl] Missing message: "${id}" for locale: "${locale}"` +
+    // This prevents warnings from littering the console in development
+    // when no `messages` are passed into the <IntlProvider> for the
+    // default locale, and a default message is in the source.
+    if (
+      !defaultMessage ||
+      (locale && locale.toLowerCase() !== defaultLocale.toLowerCase())
+    ) {
+      onError(
+        createError(
+          `Missing message: "${id}" for locale: "${locale}"` +
             (defaultMessage ? ', using default message as fallback.' : '')
-        );
-      }
+        )
+      );
     }
   }
 
@@ -245,24 +239,21 @@ export function formatMessage(
 
       formattedMessage = formatter.format(values);
     } catch (e) {
-      if (process.env.NODE_ENV !== 'production') {
-        console.error(
-          `[React Intl] Error formatting the default message for: "${id}"` +
-            `\n${e}`
-        );
-      }
+      onError(
+        createError(`Error formatting the default message for: "${id}"`, e)
+      );
     }
   }
 
   if (!formattedMessage) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(
-        `[React Intl] Cannot format message: "${id}", ` +
-          `using message ${
-            message || defaultMessage ? 'source' : 'id'
-          } as fallback.`
-      );
-    }
+    onError(
+      createError(
+        `Cannot format message: "${id}", ` +
+          `using message ${message || defaultMessage
+            ? 'source'
+            : 'id'} as fallback.`
+      )
+    );
   }
 
   return formattedMessage || message || defaultMessage || id;

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,3 +101,14 @@ export function shouldIntlComponentUpdate(
     )
   );
 }
+
+export function createError(message, exception) {
+  const eMsg = exception ? `\n${exception}` : '';
+  return `[React Intl] ${message}${eMsg}`;
+}
+
+export function defaultErrorHandler(error) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(error);
+  }
+}

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -66,6 +66,8 @@ describe('format API', () => {
 
             defaultLocale: 'en',
             defaultFormats: {},
+
+            onError: consoleError,
         };
 
         state = {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,12 @@
+import {createError} from "../../src/utils";
+
+describe('utils', () => {
+    describe('createError', () => {
+        it ('should add exception message', () => {
+           const e = new TypeError("unit test");
+
+           expect(createError('error message', e)).toEqual("[React Intl] error message\nTypeError: unit test");
+           expect(createError('error message')).toEqual("[React Intl] error message");
+        });
+    });
+});


### PR DESCRIPTION
The default handler property acts as previously: it uses `console.error` if the environment is not 'production'. Now the developer can override this setting and provides its custom error handler.

For now, the `createError` function returns a string (matching the previous behavior)... maybe we could return an `Error` object?