### PR TITLE
Add timeZone prop to IntlProvider

### DIFF
--- a/examples/explicit-timezone/.gitignore
+++ b/examples/explicit-timezone/.gitignore
@@ -1,0 +1,15 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+
+# testing
+coverage
+
+# production
+build
+
+# misc
+.DS_Store
+.env
+npm-debug.log

--- a/examples/explicit-timezone/README.md
+++ b/examples/explicit-timezone/README.md
@@ -1,0 +1,13 @@
+React Intl Explicit Timezone Example
+==============================
+
+This app demonstrates the ability to explicitly pass a timeZone to IntlProvider so that times and dates are formatted accordingly
+
+## Running Example
+
+**In the project directory, run:**
+```
+$ npm install
+$ npm start
+```
+**Open [http://localhost:3000](http://localhost:3000) to view it in the browser.**

--- a/examples/explicit-timezone/package.json
+++ b/examples/explicit-timezone/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-intl-example-explicit-timezone",
+  "version": "1.0.0",
+  "description": "React Intl Explicit Timezone Example",
+  "private": true,
+  "main": "index.js",
+  "author": "Bryan Richards <brichardssa@gmail.com>",
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "react-scripts": "0.6.0"
+  },
+  "dependencies": {
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "react-intl": "file:../../"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/examples/explicit-timezone/package.json
+++ b/examples/explicit-timezone/package.json
@@ -10,9 +10,10 @@
     "react-scripts": "0.6.0"
   },
   "dependencies": {
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2",
-    "react-intl": "^2.1.5"
+    "prop-types": "^15.5.4",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-intl": "^2.3.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/explicit-timezone/package.json
+++ b/examples/explicit-timezone/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-intl": "file:../../"
+    "react-intl": "^2.1.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/explicit-timezone/public/index.html
+++ b/examples/explicit-timezone/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>React Intl Explicit Timezone Example</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=Intl.~locale.en"></script>
+    </body>
+</html>

--- a/examples/explicit-timezone/src/App.js
+++ b/examples/explicit-timezone/src/App.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {FormattedDate, FormattedTime} from 'react-intl';
 
 class App extends Component {

--- a/examples/explicit-timezone/src/App.js
+++ b/examples/explicit-timezone/src/App.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react';
+import {FormattedDate, FormattedTime} from 'react-intl';
+
+class App extends Component {
+    render() {
+        const currentTime = new Date();
+
+        return <p>
+            The date in Tokyo is: <FormattedDate value={currentTime} />
+            <br />
+            The time in Tokyo is: <FormattedTime value={currentTime} />
+        </p>;
+    }
+}
+
+
+export default App;

--- a/examples/explicit-timezone/src/App.js
+++ b/examples/explicit-timezone/src/App.js
@@ -1,9 +1,9 @@
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import {FormattedDate, FormattedTime} from 'react-intl';
 
 class App extends Component {
     render() {
-        const currentTime = new Date();
+        const {currentTime} = this.props;
 
         return <p>
             The date in Tokyo is: <FormattedDate value={currentTime} />
@@ -13,5 +13,12 @@ class App extends Component {
     }
 }
 
+App.propTypes = {
+    currentTime: PropTypes.object,
+};
+
+App.defaultProps = {
+    currentTime: new Date(),
+};
 
 export default App;

--- a/examples/explicit-timezone/src/index.js
+++ b/examples/explicit-timezone/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {IntlProvider} from 'react-intl';
+import App from './App';
+
+ReactDOM.render(
+    <IntlProvider locale="en" timeZone="Asia/Tokyo">
+        <App />
+    </IntlProvider>,
+    document.getElementById('root')
+);

--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -24,6 +24,7 @@ const intlFormatPropNames = Object.keys(intlFormatPropTypes);
 const defaultProps = {
   formats: {},
   messages: {},
+  timeZone: null,
   textComponent: 'span',
 
   defaultLocale: 'en',

--- a/src/format.js
+++ b/src/format.js
@@ -56,13 +56,11 @@ export function formatDate(config, state, value, options = {}) {
   const {format} = options;
 
   let date = new Date(value);
-  let defaults = format && getNamedFormat(formats, 'date', format);
-  let configTimeZone = timeZone ? {timeZone} : {};
-  let filteredOptions = filterProps(
-    options,
-    DATE_TIME_FORMAT_OPTIONS,
-    {...configTimeZone, ...defaults}
-  );
+  let defaults = {
+    ...(timeZone && {timeZone}),
+    ...(format && getNamedFormat(formats, 'date', format)),
+  };
+  let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
 
   try {
     return state.getDateTimeFormat(locale, filteredOptions).format(date);
@@ -80,13 +78,11 @@ export function formatTime(config, state, value, options = {}) {
   const {format} = options;
 
   let date = new Date(value);
-  let defaults = format && getNamedFormat(formats, 'time', format);
-  let configTimeZone = timeZone ? {timeZone} : {};
-  let filteredOptions = filterProps(
-    options,
-    DATE_TIME_FORMAT_OPTIONS,
-    {...configTimeZone, ...defaults}
-  );
+  let defaults = {
+    ...(timeZone && {timeZone}),
+    ...(format && getNamedFormat(formats, 'time', format)),
+  };
+  let filteredOptions = filterProps(options, DATE_TIME_FORMAT_OPTIONS, defaults);
 
   if (
     !filteredOptions.hour &&

--- a/src/format.js
+++ b/src/format.js
@@ -52,15 +52,16 @@ function getNamedFormat(formats, type, name) {
 }
 
 export function formatDate(config, state, value, options = {}) {
-  const {locale, formats} = config;
+  const {locale, formats, timeZone} = config;
   const {format} = options;
 
   let date = new Date(value);
   let defaults = format && getNamedFormat(formats, 'date', format);
+  let configTimeZone = timeZone ? {timeZone} : {};
   let filteredOptions = filterProps(
     options,
     DATE_TIME_FORMAT_OPTIONS,
-    defaults
+    {...configTimeZone, ...defaults}
   );
 
   try {
@@ -75,15 +76,16 @@ export function formatDate(config, state, value, options = {}) {
 }
 
 export function formatTime(config, state, value, options = {}) {
-  const {locale, formats} = config;
+  const {locale, formats, timeZone} = config;
   const {format} = options;
 
   let date = new Date(value);
   let defaults = format && getNamedFormat(formats, 'time', format);
+  let configTimeZone = timeZone ? {timeZone} : {};
   let filteredOptions = filterProps(
     options,
     DATE_TIME_FORMAT_OPTIONS,
-    defaults
+    {...configTimeZone, ...defaults}
   );
 
   if (

--- a/src/types.js
+++ b/src/types.js
@@ -24,6 +24,7 @@ const funcReq = func.isRequired;
 
 export const intlConfigPropTypes = {
   locale: string,
+  timeZone: string,
   formats: object,
   messages: object,
   textComponent: any,

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -153,7 +153,9 @@ describe('<IntlProvider>', () => {
         const {intl} = renderer.getMountedInstance().getChildContext();
 
         INTL_SHAPE_PROP_NAMES.forEach((propName) => {
-            expect(intl[propName]).toExist(`Missing context.intl prop: ${propName}`);
+            if(propName !== 'timeZone') {
+                expect(intl[propName]).toExist(`Missing context.intl prop: ${propName}`);
+            }
         });
     });
 
@@ -180,6 +182,23 @@ describe('<IntlProvider>', () => {
         INTL_CONFIG_PROP_NAMES.forEach((propName) => {
             expect(intl[propName]).toBe(props[propName]);
         });
+    });
+
+    it('provides `context.intl` with timeZone from intl config props when it is specified', () => {
+        const props = {
+            timeZone: 'Europe/Paris'
+        };
+
+        const el = (
+            <IntlProvider {...props}>
+                <Child />
+            </IntlProvider>
+        );
+
+        renderer.render(el);
+        const {intl} = renderer.getMountedInstance().getChildContext();
+
+        expect(intl.timeZone).toBe('Europe/Paris');
     });
 
     it('provides `context.intl` with values from `defaultProps` for missing or undefined props', () => {
@@ -279,6 +298,7 @@ describe('<IntlProvider>', () => {
     it('shadows inherited intl config props from an <IntlProvider> ancestor', () => {
         const props = {
             locale  : 'en',
+            timeZone  : 'Australia/Adelaide',
             formats : {
                 date: {
                     'year-only': {
@@ -305,6 +325,7 @@ describe('<IntlProvider>', () => {
         const el = (
             <IntlProvider
                 locale="fr"
+                timeZone="Atlantic/Azores"
                 formats={{}}
                 messages={{}}
                 defaultLocale="en"

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -129,7 +129,7 @@ describe('<IntlProvider>', () => {
         );
     });
 
-    it('renderes its `children`', () => {
+    it('renders its `children`', () => {
         const el = (
             <IntlProvider locale="en">
                 <Child />
@@ -186,7 +186,7 @@ describe('<IntlProvider>', () => {
 
     it('provides `context.intl` with timeZone from intl config props when it is specified', () => {
         const props = {
-            timeZone: 'Europe/Paris'
+            timeZone: 'Europe/Paris',
         };
 
         const el = (

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -153,15 +153,14 @@ describe('<IntlProvider>', () => {
         const {intl} = renderer.getMountedInstance().getChildContext();
 
         INTL_SHAPE_PROP_NAMES.forEach((propName) => {
-            if(propName !== 'timeZone') {
-                expect(intl[propName]).toExist(`Missing context.intl prop: ${propName}`);
-            }
+            expect(intl[propName]).toNotBe(undefined, `Missing context.intl prop: ${propName}`);
         });
     });
 
     it('provides `context.intl` with values from intl config props', () => {
         const props = {
             locale       : 'fr-FR',
+            timeZone     : 'UTC',
             formats      : {},
             messages     : {},
             textComponent: 'span',
@@ -255,6 +254,7 @@ describe('<IntlProvider>', () => {
     it('inherits from an <IntlProvider> ancestor', () => {
         const props = {
             locale  : 'en',
+            timeZone: 'UTC',
             formats : {
                 date: {
                     'year-only': {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -134,6 +134,22 @@ describe('format API', () => {
             expect(formatDate(timestamp)).toBe(df.format(timestamp));
         });
 
+        it('uses the time zone specified by the provider', () => {
+            const timestamp = Date.now();
+            config = {...config, timeZone: 'Pacific/Wake'};
+            formatDate = f.formatDate.bind(null, config, state);
+            const wakeDf = new Intl.DateTimeFormat(config.locale, {
+                timeZone: 'Pacific/Wake'
+            });
+            expect(formatDate(timestamp)).toBe(wakeDf.format(timestamp));
+            config = {...config, timeZone: 'Pacific/Samoa'};
+            formatDate = f.formatDate.bind(null, config, state);
+            const samoaDf = new Intl.DateTimeFormat(config.locale, {
+                timeZone: 'Pacific/Samoa'
+            });
+            expect(formatDate(timestamp)).toBe(samoaDf.format(timestamp));
+        });
+
         describe('options', () => {
             it('accepts empty options', () => {
                 expect(formatDate(0, {})).toBe(df.format(0));
@@ -187,6 +203,16 @@ describe('format API', () => {
                     `[React Intl] No date format named: ${format}`
                 );
             });
+
+            it('uses time zone specified in options over the one passed through by the provider', () => {
+                const timestamp = Date.now();
+                config = {...config, timeZone: 'Pacific/Wake'};
+                formatDate = f.formatDate.bind(null, config, state);
+                const samoaDf = new Intl.DateTimeFormat(config.locale, {
+                    timeZone: 'Pacific/Samoa'
+                });
+                expect(formatDate(timestamp, {timeZone: 'Pacific/Samoa'})).toBe(samoaDf.format(timestamp));
+            });
         });
     });
 
@@ -234,6 +260,26 @@ describe('format API', () => {
         it('formats date ms timestamp values', () => {
             const timestamp = Date.now();
             expect(formatTime(timestamp)).toBe(df.format(timestamp));
+        });
+
+        it('uses the time zone specified by the provider', () => {
+            const timestamp = Date.now();
+            config = {...config, timeZone: 'Africa/Johannesburg'};
+            formatTime = f.formatTime.bind(null, config, state);
+            const johannesburgDf = new Intl.DateTimeFormat(config.locale, {
+                hour: 'numeric',
+                minute: 'numeric',
+                timeZone: 'Africa/Johannesburg'
+            });
+            expect(formatTime(timestamp)).toBe(johannesburgDf.format(timestamp));
+            config = {...config, timeZone: 'America/Chicago'};
+            formatTime = f.formatTime.bind(null, config, state);
+            const chicagoDf = new Intl.DateTimeFormat(config.locale, {
+                hour: 'numeric',
+                minute: 'numeric',
+                timeZone: 'America/Chicago'
+            });
+            expect(formatTime(timestamp)).toBe(chicagoDf.format(timestamp));
         });
 
         describe('options', () => {
@@ -318,6 +364,18 @@ describe('format API', () => {
                 const hour = 'numeric';
                 df = new Intl.DateTimeFormat(locale, {hour});
                 expect(formatTime(date, {hour})).toBe(df.format(date));
+            });
+
+            it('uses time zone specified in options over the one passed through by the provider', () => {
+                const timestamp = Date.now();
+                config = {...config, timeZone: 'Africa/Johannesburg'};
+                formatTime = f.formatTime.bind(null, config, state);
+                const chicagoDf = new Intl.DateTimeFormat(config.locale, {
+                    hour: 'numeric',
+                    minute: 'numeric',
+                    timeZone: 'America/Chicago'
+                });
+                expect(formatTime(timestamp, {timeZone: 'America/Chicago'})).toBe(chicagoDf.format(timestamp));
             });
         });
     });

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -136,13 +136,13 @@ describe('format API', () => {
 
         it('uses the time zone specified by the provider', () => {
             const timestamp = Date.now();
-            config = {...config, timeZone: 'Pacific/Wake'};
+            config.timeZone =  'Pacific/Wake';
             formatDate = f.formatDate.bind(null, config, state);
             const wakeDf = new Intl.DateTimeFormat(config.locale, {
                 timeZone: 'Pacific/Wake',
             });
             expect(formatDate(timestamp)).toBe(wakeDf.format(timestamp));
-            config = {...config, timeZone: 'Asia/Shanghai'};
+            config.timeZone = 'Asia/Shanghai';
             formatDate = f.formatDate.bind(null, config, state);
             const shanghaiDf = new Intl.DateTimeFormat(config.locale, {
                 timeZone: 'Asia/Shanghai',
@@ -206,7 +206,7 @@ describe('format API', () => {
 
             it('uses time zone specified in options over the one passed through by the provider', () => {
                 const timestamp = Date.now();
-                config = {...config, timeZone: 'Pacific/Wake'};
+                config.timeZone = 'Pacific/Wake';
                 formatDate = f.formatDate.bind(null, config, state);
                 const shanghaiDf = new Intl.DateTimeFormat(config.locale, {
                     timeZone: 'Asia/Shanghai',
@@ -264,7 +264,7 @@ describe('format API', () => {
 
         it('uses the time zone specified by the provider', () => {
             const timestamp = Date.now();
-            config = {...config, timeZone: 'Africa/Johannesburg'};
+            config.timeZone = 'Africa/Johannesburg';
             formatTime = f.formatTime.bind(null, config, state);
             const johannesburgDf = new Intl.DateTimeFormat(config.locale, {
                 hour: 'numeric',
@@ -272,7 +272,7 @@ describe('format API', () => {
                 timeZone: 'Africa/Johannesburg',
             });
             expect(formatTime(timestamp)).toBe(johannesburgDf.format(timestamp));
-            config = {...config, timeZone: 'America/Chicago'};
+            config.timeZone = 'America/Chicago';
             formatTime = f.formatTime.bind(null, config, state);
             const chicagoDf = new Intl.DateTimeFormat(config.locale, {
                 hour: 'numeric',
@@ -368,7 +368,7 @@ describe('format API', () => {
 
             it('uses time zone specified in options over the one passed through by the provider', () => {
                 const timestamp = Date.now();
-                config = {...config, timeZone: 'Africa/Johannesburg'};
+                config.timeZone = 'Africa/Johannesburg';
                 formatTime = f.formatTime.bind(null, config, state);
                 const chicagoDf = new Intl.DateTimeFormat(config.locale, {
                     hour: 'numeric',

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -139,13 +139,13 @@ describe('format API', () => {
             config = {...config, timeZone: 'Pacific/Wake'};
             formatDate = f.formatDate.bind(null, config, state);
             const wakeDf = new Intl.DateTimeFormat(config.locale, {
-                timeZone: 'Pacific/Wake'
+                timeZone: 'Pacific/Wake',
             });
             expect(formatDate(timestamp)).toBe(wakeDf.format(timestamp));
             config = {...config, timeZone: 'Pacific/Samoa'};
             formatDate = f.formatDate.bind(null, config, state);
             const samoaDf = new Intl.DateTimeFormat(config.locale, {
-                timeZone: 'Pacific/Samoa'
+                timeZone: 'Pacific/Samoa',
             });
             expect(formatDate(timestamp)).toBe(samoaDf.format(timestamp));
         });
@@ -209,7 +209,7 @@ describe('format API', () => {
                 config = {...config, timeZone: 'Pacific/Wake'};
                 formatDate = f.formatDate.bind(null, config, state);
                 const samoaDf = new Intl.DateTimeFormat(config.locale, {
-                    timeZone: 'Pacific/Samoa'
+                    timeZone: 'Pacific/Samoa',
                 });
                 expect(formatDate(timestamp, {timeZone: 'Pacific/Samoa'})).toBe(samoaDf.format(timestamp));
             });
@@ -269,7 +269,7 @@ describe('format API', () => {
             const johannesburgDf = new Intl.DateTimeFormat(config.locale, {
                 hour: 'numeric',
                 minute: 'numeric',
-                timeZone: 'Africa/Johannesburg'
+                timeZone: 'Africa/Johannesburg',
             });
             expect(formatTime(timestamp)).toBe(johannesburgDf.format(timestamp));
             config = {...config, timeZone: 'America/Chicago'};
@@ -277,7 +277,7 @@ describe('format API', () => {
             const chicagoDf = new Intl.DateTimeFormat(config.locale, {
                 hour: 'numeric',
                 minute: 'numeric',
-                timeZone: 'America/Chicago'
+                timeZone: 'America/Chicago',
             });
             expect(formatTime(timestamp)).toBe(chicagoDf.format(timestamp));
         });
@@ -373,7 +373,7 @@ describe('format API', () => {
                 const chicagoDf = new Intl.DateTimeFormat(config.locale, {
                     hour: 'numeric',
                     minute: 'numeric',
-                    timeZone: 'America/Chicago'
+                    timeZone: 'America/Chicago',
                 });
                 expect(formatTime(timestamp, {timeZone: 'America/Chicago'})).toBe(chicagoDf.format(timestamp));
             });

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -142,12 +142,12 @@ describe('format API', () => {
                 timeZone: 'Pacific/Wake',
             });
             expect(formatDate(timestamp)).toBe(wakeDf.format(timestamp));
-            config = {...config, timeZone: 'Pacific/Samoa'};
+            config = {...config, timeZone: 'Asia/Shanghai'};
             formatDate = f.formatDate.bind(null, config, state);
-            const samoaDf = new Intl.DateTimeFormat(config.locale, {
-                timeZone: 'Pacific/Samoa',
+            const shanghaiDf = new Intl.DateTimeFormat(config.locale, {
+                timeZone: 'Asia/Shanghai',
             });
-            expect(formatDate(timestamp)).toBe(samoaDf.format(timestamp));
+            expect(formatDate(timestamp)).toBe(shanghaiDf.format(timestamp));
         });
 
         describe('options', () => {
@@ -208,10 +208,10 @@ describe('format API', () => {
                 const timestamp = Date.now();
                 config = {...config, timeZone: 'Pacific/Wake'};
                 formatDate = f.formatDate.bind(null, config, state);
-                const samoaDf = new Intl.DateTimeFormat(config.locale, {
-                    timeZone: 'Pacific/Samoa',
+                const shanghaiDf = new Intl.DateTimeFormat(config.locale, {
+                    timeZone: 'Asia/Shanghai',
                 });
-                expect(formatDate(timestamp, {timeZone: 'Pacific/Samoa'})).toBe(samoaDf.format(timestamp));
+                expect(formatDate(timestamp, {timeZone: 'Asia/Shanghai'})).toBe(shanghaiDf.format(timestamp));
             });
         });
     });


### PR DESCRIPTION
Resolve #702 

This adds a timeZone prop to IntlProvider which will be used as the default timeZone for formatDate and formatTime.

My team would like to see #707 merged but there has been no activity for two months. Here are the same commits with the requested changes.