### PR TITLE
Issue: https://github.com/yahoo/react-intl/issues/557

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -27,6 +27,7 @@ const defaultProps = {
 
     defaultLocale : 'en',
     defaultFormats: {},
+    defaultMessages: {},
 };
 
 export default class IntlProvider extends Component {
@@ -131,6 +132,7 @@ export default class IntlProvider extends Component {
                 locale  : defaultLocale,
                 formats : defaultFormats,
                 messages: defaultProps.messages,
+                defaultMessages: defaultProps.defaultMessages,
             };
         }
 

--- a/src/format.js
+++ b/src/format.js
@@ -179,12 +179,15 @@ export function formatMessage(config, state, messageDescriptor = {}, values = {}
         messages,
         defaultLocale,
         defaultFormats,
+        defaultMessages,
     } = config;
 
     const {
         id,
-        defaultMessage,
     } = messageDescriptor;
+
+    const defaultMessage =
+      messageDescriptor.defaultMessage || defaultMessages[id];
 
     // `id` is a required field of a Message Descriptor.
     invariant(id, '[React Intl] An `id` must be provided to format a message.');
@@ -221,12 +224,9 @@ export function formatMessage(config, state, messageDescriptor = {}, values = {}
             // This prevents warnings from littering the console in development
             // when no `messages` are passed into the <IntlProvider> for the
             // default locale, and a default message is in the source.
-            if (!defaultMessage ||
-                (locale && locale.toLowerCase() !== defaultLocale.toLowerCase())) {
-
+            if (!defaultMessage) {
                 console.error(
-                    `[React Intl] Missing message: "${id}" for locale: "${locale}"` +
-                    (defaultMessage ? ', using default message as fallback.' : '')
+                    `[React Intl] Missing message: "${id}" for locale: "${locale}"`
                 );
             }
         }

--- a/src/types.js
+++ b/src/types.js
@@ -13,13 +13,14 @@ const numeric2digit = oneOf(['numeric', '2-digit']);
 const funcReq = func.isRequired;
 
 export const intlConfigPropTypes = {
-    locale       : string,
-    formats      : object,
-    messages     : object,
-    textComponent: any,
+    locale         : string,
+    formats        : object,
+    messages       : object,
+    textComponent  : any,
 
-    defaultLocale : string,
-    defaultFormats: object,
+    defaultLocale  : string,
+    defaultFormats : object,
+    defaultMessages: object
 };
 
 export const intlFormatPropTypes = {

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -166,6 +166,7 @@ describe('<IntlProvider>', () => {
 
             defaultLocale : 'en-US',
             defaultFormats: {},
+            defaultMessages: {},
         };
 
         const el = (
@@ -256,6 +257,7 @@ describe('<IntlProvider>', () => {
                     },
                 },
             },
+            defaultMessages: {},
         };
 
         const parentIntlProvider = new IntlProvider(props, {});
@@ -310,6 +312,7 @@ describe('<IntlProvider>', () => {
                 defaultLocale="en"
                 defaultFormats={{}}
                 textComponent="span"
+                defaultMessages={{}}
             >
                 <Child />
             </IntlProvider>

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -66,6 +66,16 @@ describe('format API', () => {
 
             defaultLocale: 'en',
             defaultFormats: {},
+
+            defaultMessages: {
+                no_args: 'Hello, World!',
+                with_arg: 'Hello, {name}!',
+                with_named_format: 'It is {now, date, year-only}',
+                with_html: 'Hello, <b>{name}</b>!',
+
+                empty: '',
+                missing_named_format: 'missing {now, date, format_missing}',
+            },
         };
 
         state = {
@@ -729,11 +739,6 @@ describe('format API', () => {
                     id: id,
                     defaultMessage: messages.with_arg,
                 }, values)).toBe(mf.format(values));
-
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
-                    `[React Intl] Missing message: "${id}" for locale: "${locale}", using default message as fallback.`
-                );
             });
 
             it('warns when `message` and `defaultMessage` are missing', () => {
@@ -839,14 +844,11 @@ describe('format API', () => {
                     defaultMessage: messages.invalid,
                 })).toBe(messages.invalid);
 
-                expect(consoleError.calls.length).toBe(3);
+                expect(consoleError.calls.length).toBe(2);
                 expect(consoleError.calls[0].arguments[0]).toContain(
-                    `[React Intl] Missing message: "${id}" for locale: "${locale}", using default message as fallback.`
-                );
-                expect(consoleError.calls[1].arguments[0]).toContain(
                     `[React Intl] Error formatting the default message for: "${id}"`
                 );
-                expect(consoleError.calls[2].arguments[0]).toContain(
+                expect(consoleError.calls[1].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message source as fallback.`
                 );
             });


### PR DESCRIPTION
Problem: we have a number of language packages, when a key is missing from one language, we want to default to the corresponding English value. This is the default behaviour for GWT and Cocoon, the two web development frameworks we used previously.

The changeset implments this default behaviour. I added one more property called defaultMessages.