### PR TITLE
Undo (soft) breaking change introduced in 93c0a35 & #816.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 coverage/
 examples/
 scripts/
-src/
 test/
 rollup.config.*
 .*


### PR DESCRIPTION
We say "soft" breaking because it was not a strict contract between `react-intl` and
consumers that raw `src/*` files be included in the npm package. If one were to want
a custom build of `react-intl` for their own purposes the npm package is now no longer
a viable location for that source code.
