### PR TITLE
fix bug: message is empty string cause error

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -200,7 +200,7 @@ export function formatMessage(config, state, messageDescriptor = {}, values = {}
 
     let formattedMessage;
 
-    if (message) {
+    if (Object.prototype.toString.apply(message) === '[object String]') {
         try {
             let formatter = state.getMessageFormat(
                 message, locale, formats


### PR DESCRIPTION
fix bug: message is empty string cause error.
may cause unnessary error when we intent to have empty value as translate result