### PR TITLE
adds message flattening utility

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -11,7 +11,7 @@ import IntlRelativeFormat from 'intl-relativeformat';
 import IntlPluralFormat from '../plural';
 import memoizeIntlConstructor from 'intl-format-cache';
 import invariant from 'invariant';
-import {shouldIntlComponentUpdate, filterProps} from '../utils';
+import {shouldIntlComponentUpdate, filterProps, flattenMessages} from '../utils';
 import {intlConfigPropTypes, intlFormatPropTypes, intlShape} from '../types';
 import * as format from '../format';
 import {hasLocaleData} from '../locale-data-registry';
@@ -131,7 +131,7 @@ export default class IntlProvider extends Component {
                 ...config,
                 locale  : defaultLocale,
                 formats : defaultFormats,
-                messages: defaultProps.messages,
+                messages: flattenMessages(defaultProps.messages),
             };
         }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,3 +91,20 @@ export function shouldIntlComponentUpdate(
         ))
     );
 }
+
+export function flattenMessages(
+    nestedMessages,
+    flatMessages = {},
+    currentKey = ''
+) {
+    for (let k in nestedMessages) {
+        const v = nestedMessages[k];
+        const newKey = currentKey === '' ? k : currentKey + '.' + k;
+        if (typeof v !== 'string') {
+            flattenMessages(v, flatMessages, newKey);
+        } else {
+            flatMessages[`${newKey}`] = v;
+        }
+    }
+    return flatMessages;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,6 +1243,10 @@ commander@^2.8.1, commander@^2.9.0, commander@~2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@~2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 component-emitter@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -4583,10 +4587,10 @@ uglify-js@^2.6, uglify-js@^2.6.2:
     yargs "~3.10.0"
 
 uglify-js@^3.0.9:
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.24.tgz#ee93400ad9857fb7a1671778db83f6a23f033121"
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.27.tgz#a97db8c8ba6b9dba4e2f88d86aa9548fa6320034"
   dependencies:
-    commander "~2.9.0"
+    commander "~2.11.0"
     source-map "~0.5.1"
 
 uglify-to-browserify@~1.0.0:


### PR DESCRIPTION
React-intl expects the messages to be of the form of a flat hash with keys like 'user.form.title"

YAML parsers create deeply nested hashes.

This takes deeply nested hashes of the form { user: {form: { title: 'x'}}} and flattens them to {'user.form.title': 'x'}