### PR TITLE
Support React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "invariant": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.0.0",
+    "react": "^0.14.9 || ^15.0.0 || ^16.0.0",
     "prop-types": "^15.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
```
...
warning "react-intl@2.3.0" has incorrect peer dependency "react@^0.14.9 || ^15.0.0".
...
```
