### PR TITLE
Replace string ref in injectIntl HOC with functional one

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -41,7 +41,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
           '`injectIntl()`'
       );
 
-      return this.refs.wrappedInstance;
+      return this._wrappedInstance;
     }
 
     render() {
@@ -49,7 +49,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
         <WrappedComponent
           {...this.props}
           {...{[intlPropName]: this.context.intl}}
-          ref={withRef ? 'wrappedInstance' : null}
+          ref={withRef ? (ref => this._wrappedInstance = ref) : null}
         />
       );
     }


### PR DESCRIPTION
We are using `injectIntl` with `{ withRef: true }` and in React 16 we get an error (e.g. "Element ref was specified as a string (wrappedInstance) but no owner was set. You may have multiple copies of React loaded.", see https://github.com/facebook/react/blob/master/docs/warnings/refs-must-have-owner.md) when using it with SSR. There is a workaround for this issue in React repo (see a discussion at https://github.com/facebook/react/issues/3344). This PR is trying to fix the issue by replacing string ref by functional one.