### PR TITLE
Added prop-types 15.6.0 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.0.0 || ^16.0.0",
-    "prop-types": "^15.5.4"
+    "prop-types": "^15.5.4 || ^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",


### PR DESCRIPTION
After upgrading to react 16 and prop-types 15.6.0 I noticed that react-intl throws a peerDependency warning.

This fix it to stop this warning and allow downstream modules to build without peerDependency failures.