### PR TITLE
spike: gracefull failback for missing provider

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -10,7 +10,7 @@
 import React, {Component} from 'react';
 import invariant from 'invariant';
 import {intlShape} from './types';
-import {invariantIntlContext} from './utils';
+import IntlProvider from './components/provider';
 
 function getDisplayName(Component) {
   return Component.displayName || Component.name || 'Component';
@@ -30,7 +30,6 @@ export default function injectIntl(WrappedComponent, options = {}) {
 
     constructor(props, context) {
       super(props, context);
-      invariantIntlContext(context);
     }
 
     getWrappedInstance() {
@@ -45,12 +44,21 @@ export default function injectIntl(WrappedComponent, options = {}) {
     }
 
     render() {
-      return (
-        <WrappedComponent
-          {...this.props}
-          {...{[intlPropName]: this.context.intl}}
-          ref={withRef ? 'wrappedInstance' : null}
-        />
+      if (!this.context.intl) {
+        const DeepWrappedComponent = injectIntl(WrappedComponent);
+        return (
+          <IntlProvider>
+            <DeepWrappedComponent />
+          </IntlProvider>
+        );
+      }
+
+     return (
+       <WrappedComponent
+         {...this.props}
+         {...{[intlPropName]: this.context.intl}}
+         ref={withRef ? 'wrappedInstance' : null}
+       />
       );
     }
   }

--- a/test/unit/inject.js
+++ b/test/unit/inject.js
@@ -39,14 +39,6 @@ describe('injectIntl()', () => {
         });
     });
 
-    it('throws when <IntlProvider> is missing from ancestry', () => {
-        const Injected = injectIntl(Wrapped);
-
-        expect(() => renderer.render(<Injected />)).toThrow(
-            '[React Intl] Could not find required `intl` object. <IntlProvider> needs to exist in the component ancestry.'
-        );
-    });
-
     it('renders <WrappedComponent> with `intl` prop', () => {
         const Injected = injectIntl(Wrapped);
         const {intl} = intlProvider.getChildContext();


### PR DESCRIPTION
Spike for: https://github.com/yahoo/react-intl/issues/1079

This is just a fast example that when `IntlProvider` is missing, intl injected component could still work using default translations.