### PR TITLE
Upgrade prop-types dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.0.0 || ^16.0.0",
-    "prop-types": "^15.5.4"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",
@@ -105,7 +105,7 @@
     "jest": "^19.0.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1.6.1",
-    "prop-types": "^15.5.4",
+    "prop-types": "^15.6.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-test-renderer": "^15.5.4",


### PR DESCRIPTION
15.5.4, which this previously relied upon, is marked as having a critical issue: 

> Note: this release has a critical issue and was deprecated. Please update to 15.5.7 or higher.

https://github.com/facebook/prop-types/blob/master/CHANGELOG.md

This upgrades instead to the latest version, which also has a nicer license.