### PR TITLE
Uplift to intl-relativeformat 2.1.0 and Fix Unit Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "intl-format-cache": "^2.0.5",
     "intl-messageformat": "^2.1.0",
-    "intl-relativeformat": "^2.0.0",
+    "intl-relativeformat": "^2.1.0",
     "invariant": "^2.1.1"
   },
   "peerDependencies": {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -385,12 +385,12 @@ describe('format API', () => {
                 expect(() => formatRelative(0, {units: 'second'})).toNotThrow();
             });
 
-            it('fallsback and wanrs on invalid IntlRelativeFormat options', () => {
+            it('falls back and warns on invalid IntlRelativeFormat options', () => {
                 expect(formatRelative(0, {units: 'invalid'})).toBe(String(new Date(0)));
                 expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toBe(
-                    '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of: "second", "minute", "hour", "day", "month", "year"'
-                );
+                expect(consoleError.calls[0].arguments[0].startsWith(
+                    '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of'
+                )).toBeTruthy();
             });
 
             it('uses configured named formats', () => {


### PR DESCRIPTION
Intl Relative Format 2.1.0 included a change to supported formats [1].  Unit tests `format.js` include an exact string match to Intl Relative Format's error message, causing test to fail with:

>Expected '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of: "second", "second-short", "minute", "minute-short", "hour", "hour-short", "day", "day-short", "month", "month-short", "year", "year-short"' to be '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of: "second", "minute", "hour", "day", "month", "year"'

This PR:
  * Uplifts minimum version of `intl-relativeformat` to 2.1.0
  * Fixes unit test by relaxing matching criteria to look at the beginning of the error message instead of entire message string.

Tested with:
  * `npm run test`
  * `npm run lint`
  * `npm run test:react` also passes, but uplifts several dependencies I don't have time to validate right now so not including those.

[1] https://github.com/yahoo/intl-relativeformat/commit/d4b853f4b68ff9a4ba0afc1777dba9e02c8d3ecb