### PR TITLE
update `FormattedMessage` to accept an element as `tagName` prop

### DIFF
--- a/src/components/message.js
+++ b/src/components/message.js
@@ -23,7 +23,7 @@ export default class FormattedMessage extends Component {
   static propTypes = {
     ...messageDescriptorPropTypes,
     values: PropTypes.object,
-    tagName: PropTypes.string,
+    tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     children: PropTypes.func,
   };
 

--- a/test/unit/components/message.js
+++ b/test/unit/components/message.js
@@ -182,7 +182,7 @@ describe('<FormattedMessage>', () => {
         expect(renderedThree).toNotBe(renderedOne);
     });
 
-    it('accepts `tagName` prop', () => {
+    it('accepts string as `tagName` prop', () => {
         const {intl} = intlProvider.getChildContext();
         const descriptor = {
             id: 'hello',
@@ -194,6 +194,22 @@ describe('<FormattedMessage>', () => {
         renderer.render(el, {intl});
         expect(renderer.getRenderOutput()).toEqualJSX(
             <p>{intl.formatMessage(descriptor)}</p>
+        );
+    });
+
+    it('accepts an react element as `tagName` prop', () => {
+        const {intl} = intlProvider.getChildContext();
+        const descriptor = {
+            id: 'hello',
+            defaultMessage: 'Hello, World!',
+        };
+
+        const H1 = (children) => <h1>{children}</h1>
+        const el = <FormattedMessage {...descriptor} tagName={H1} />;
+
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <H1>{intl.formatMessage(descriptor)}</H1>
         );
     });
 


### PR DESCRIPTION
I just searched for a way to supply a simple React component as `tagName`. Added the component as the `tagName` prop, which is also working, but raising an "Invalid prop types" error.

Don't know, if this is the desired behavior. If not, please just close the PR.