### PR TITLE
Change `console.error()` to `console.warn()` for #1120

### DIFF
--- a/src/components/provider.js
+++ b/src/components/provider.js
@@ -116,7 +116,7 @@ export default class IntlProvider extends Component {
       const {locale, defaultLocale, defaultFormats} = config;
 
       if (process.env.NODE_ENV !== 'production') {
-        console.error(
+        console.warn(
           `[React Intl] Missing locale data for locale: "${locale}". ` +
             `Using default locale: "${defaultLocale}" as fallback.`
         );

--- a/src/format.js
+++ b/src/format.js
@@ -47,7 +47,7 @@ function getNamedFormat(formats, type, name) {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    console.error(`[React Intl] No ${type} format named: ${name}`);
+    console.warn(`[React Intl] No ${type} format named: ${name}`);
   }
 }
 
@@ -67,7 +67,7 @@ export function formatDate(config, state, value, options = {}) {
     return state.getDateTimeFormat(locale, filteredOptions).format(date);
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting date.\n${e}`);
+      console.warn(`[React Intl] Error formatting date.\n${e}`);
     }
   }
 
@@ -99,7 +99,7 @@ export function formatTime(config, state, value, options = {}) {
     return state.getDateTimeFormat(locale, filteredOptions).format(date);
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting time.\n${e}`);
+      console.warn(`[React Intl] Error formatting time.\n${e}`);
     }
   }
 
@@ -126,7 +126,7 @@ export function formatRelative(config, state, value, options = {}) {
     });
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting relative time.\n${e}`);
+      console.warn(`[React Intl] Error formatting relative time.\n${e}`);
     }
   } finally {
     updateRelativeFormatThresholds(oldThresholds);
@@ -146,7 +146,7 @@ export function formatNumber(config, state, value, options = {}) {
     return state.getNumberFormat(locale, filteredOptions).format(value);
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting number.\n${e}`);
+      console.warn(`[React Intl] Error formatting number.\n${e}`);
     }
   }
 
@@ -162,7 +162,7 @@ export function formatPlural(config, state, value, options = {}) {
     return state.getPluralFormat(locale, filteredOptions).format(value);
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(`[React Intl] Error formatting plural.\n${e}`);
+      console.warn(`[React Intl] Error formatting plural.\n${e}`);
     }
   }
 
@@ -200,7 +200,7 @@ export function formatMessage(
       formattedMessage = formatter.format(values);
     } catch (e) {
       if (process.env.NODE_ENV !== 'production') {
-        console.error(
+        console.warn(
           `[React Intl] Error formatting message: "${id}" for locale: "${locale}"` +
             (defaultMessage ? ', using default message as fallback.' : '') +
             `\n${e}`
@@ -216,7 +216,7 @@ export function formatMessage(
         !defaultMessage ||
         (locale && locale.toLowerCase() !== defaultLocale.toLowerCase())
       ) {
-        console.error(
+        console.warn(
           `[React Intl] Missing message: "${id}" for locale: "${locale}"` +
             (defaultMessage ? ', using default message as fallback.' : '')
         );
@@ -235,7 +235,7 @@ export function formatMessage(
       formattedMessage = formatter.format(values);
     } catch (e) {
       if (process.env.NODE_ENV !== 'production') {
-        console.error(
+        console.warn(
           `[React Intl] Error formatting the default message for: "${id}"` +
             `\n${e}`
         );
@@ -245,7 +245,7 @@ export function formatMessage(
 
   if (!formattedMessage) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(
+      console.warn(
         `[React Intl] Cannot format message: "${id}", ` +
           `using message ${message || defaultMessage
             ? 'source'

--- a/test/unit/components/date.js
+++ b/test/unit/components/date.js
@@ -8,18 +8,18 @@ import FormattedDate from '../../../src/components/date';
 expect.extend(expectJSX);
 
 describe('<FormattedDate>', () => {
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn  = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({locale: 'en'}, {});
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     it('has a `displayName`', () => {
@@ -37,11 +37,11 @@ describe('<FormattedDate>', () => {
 
         renderer.render(<FormattedDate value={0} />, {intl});
         expect(isFinite(0)).toBe(true);
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
 
         renderer.render(<FormattedDate />, {intl});
-        expect(consoleError.calls.length).toBe(1);
-        expect(consoleError.calls[0].arguments[0]).toContain(
+        expect(consoleWarn.calls.length).toBe(1);
+        expect(consoleWarn.calls[0].arguments[0]).toContain(
             '[React Intl] Error formatting date.\nRangeError'
         );
     });
@@ -114,7 +114,7 @@ describe('<FormattedDate>', () => {
             <span>{String(new Date(0))}</span>
         );
 
-        expect(consoleError.calls.length).toBeGreaterThan(0);
+        expect(consoleWarn.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/components/html-message.js
+++ b/test/unit/components/html-message.js
@@ -8,12 +8,12 @@ import FormattedHTMLMessage from '../../../src/components/html-message';
 expect.extend(expectJSX);
 
 describe('<FormattedHTMLMessage>', () => {
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn  = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({
             locale       : 'en',
@@ -22,7 +22,7 @@ describe('<FormattedHTMLMessage>', () => {
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     it('has a `displayName`', () => {

--- a/test/unit/components/message.js
+++ b/test/unit/components/message.js
@@ -8,12 +8,12 @@ import FormattedMessage from '../../../src/components/message';
 expect.extend(expectJSX);
 
 describe('<FormattedMessage>', () => {
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({
             locale       : 'en',
@@ -22,7 +22,7 @@ describe('<FormattedMessage>', () => {
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     it('has a `displayName`', () => {
@@ -60,7 +60,7 @@ describe('<FormattedMessage>', () => {
         const el = <FormattedMessage {...descriptor} values={{name: <b>Eric</b>}} />;
 
         renderer.render(el, {intl});
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
     });
 
     it('should not cause a prop warning when description is a string', () => {
@@ -74,7 +74,7 @@ describe('<FormattedMessage>', () => {
         const el = <FormattedMessage {...descriptor} values={{name: <b>Eric</b>}} />;
 
         renderer.render(el, {intl});
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
     });
 
     it('should not cause a prop warning when description is an object', () => {
@@ -91,7 +91,7 @@ describe('<FormattedMessage>', () => {
         const el = <FormattedMessage {...descriptor} values={{name: <b>Eric</b>}} />;
 
         renderer.render(el, {intl});
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
     });
 
     it('should not re-render when props and context are the same', () => {

--- a/test/unit/components/number.js
+++ b/test/unit/components/number.js
@@ -8,18 +8,18 @@ import FormattedNumber from '../../../src/components/number';
 expect.extend(expectJSX);
 
 describe('<FormattedNumber>', () => {
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({locale: 'en'}, {});
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     it('has a `displayName`', () => {
@@ -105,7 +105,7 @@ describe('<FormattedNumber>', () => {
             <span>{String(0)}</span>
         );
 
-        expect(consoleError.calls.length).toBeGreaterThan(0);
+        expect(consoleWarn.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/components/plural.js
+++ b/test/unit/components/plural.js
@@ -8,18 +8,18 @@ import FormattedPlural from '../../../src/components/plural';
 expect.extend(expectJSX);
 
 describe('<FormattedPlural>', () => {
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({locale: 'en'}, {});
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     it('has a `displayName`', () => {

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -45,6 +45,7 @@ describe('<IntlProvider>', () => {
     let renderer;
 
     beforeEach(() => {
+        // checking for console `warn`s instead of `error` for React Native debug
         consoleWarn        = spyOn(console, 'warn');
         dateNow            = spyOn(Date, 'now').andReturn(now);
         IntlProviderRender = spyOn(IntlProvider.prototype, 'render').andCallThrough();

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -38,14 +38,14 @@ describe('<IntlProvider>', () => {
 
     const Child = () => null;
 
-    let consoleError;
+    let consoleWarn;
     let dateNow;
     let IntlProviderRender;
 
     let renderer;
 
     beforeEach(() => {
-        consoleError       = spyOn(console, 'error');
+        consoleWarn        = spyOn(console, 'warn');
         dateNow            = spyOn(Date, 'now').andReturn(now);
         IntlProviderRender = spyOn(IntlProvider.prototype, 'render').andCallThrough();
 
@@ -65,7 +65,7 @@ describe('<IntlProvider>', () => {
             global.Intl = INTL;
         }
 
-        consoleError.restore();
+        consoleWarn.restore();
         dateNow.restore();
         IntlProviderRender.restore();
     });
@@ -107,8 +107,8 @@ describe('<IntlProvider>', () => {
         );
 
         renderer.render(el);
-        expect(consoleError.calls.length).toBe(1);
-        expect(consoleError.calls[0].arguments[0]).toContain(
+        expect(consoleWarn.calls.length).toBe(1);
+        expect(consoleWarn.calls[0].arguments[0]).toContain(
             '[React Intl] Missing locale data for locale: "undefined". Using default locale: "en" as fallback.'
         );
     });
@@ -123,8 +123,8 @@ describe('<IntlProvider>', () => {
         const {locale} = el.props;
 
         renderer.render(el);
-        expect(consoleError.calls.length).toBe(1);
-        expect(consoleError.calls[0].arguments[0]).toContain(
+        expect(consoleWarn.calls.length).toBe(1);
+        expect(consoleWarn.calls[0].arguments[0]).toContain(
             `[React Intl] Missing locale data for locale: "${locale}". Using default locale: "en" as fallback.`
         );
     });
@@ -269,7 +269,7 @@ describe('<IntlProvider>', () => {
         renderer.render(el, parentIntlProvider.getChildContext());
         const {intl} = renderer.getMountedInstance().getChildContext();
 
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
 
         INTL_CONFIG_PROP_NAMES.forEach((propName) => {
             expect(intl[propName]).toBe(props[propName]);
@@ -318,7 +318,7 @@ describe('<IntlProvider>', () => {
         renderer.render(el, parentIntlProvider.getChildContext());
         const {intl} = renderer.getMountedInstance().getChildContext();
 
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
 
         INTL_CONFIG_PROP_NAMES.forEach((propName) => {
             expect(intl[propName]).toNotBe(props[propName]);

--- a/test/unit/components/relative.js
+++ b/test/unit/components/relative.js
@@ -10,13 +10,13 @@ expect.extend(expectJSX);
 describe('<FormattedRelative>', () => {
     const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
     let setState;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({locale: 'en'}, {});
         setState     = spyOn(FormattedRelative.prototype, 'setState').andCallThrough();
@@ -31,7 +31,7 @@ describe('<FormattedRelative>', () => {
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
         setState.restore();
     });
 
@@ -50,11 +50,11 @@ describe('<FormattedRelative>', () => {
 
         renderer.render(<FormattedRelative value={0} />, {intl});
         expect(isFinite(0)).toBe(true);
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
 
         renderer.render(<FormattedRelative value={NaN} />, {intl});
-        expect(consoleError.calls.length).toBe(1);
-        expect(consoleError.calls[0].arguments[0]).toContain(
+        expect(consoleWarn.calls.length).toBe(1);
+        expect(consoleWarn.calls[0].arguments[0]).toContain(
             '[React Intl] Error formatting relative time.\nRangeError'
         );
 
@@ -136,7 +136,7 @@ describe('<FormattedRelative>', () => {
             <span>{String(new Date(0))}</span>
         );
 
-        expect(consoleError.calls.length).toBeGreaterThan(0);
+        expect(consoleWarn.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/components/time.js
+++ b/test/unit/components/time.js
@@ -8,18 +8,18 @@ import FormattedTime from '../../../src/components/time';
 expect.extend(expectJSX);
 
 describe('<FormattedTime>', () => {
-    let consoleError;
+    let consoleWarn;
     let renderer;
     let intlProvider;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn = spyOn(console, 'warn');
         renderer     = createRenderer();
         intlProvider = new IntlProvider({locale: 'en'}, {});
     });
 
     afterEach(() => {
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     it('has a `displayName`', () => {
@@ -37,11 +37,11 @@ describe('<FormattedTime>', () => {
 
         renderer.render(<FormattedTime value={0} />, {intl});
         expect(isFinite(0)).toBe(true);
-        expect(consoleError.calls.length).toBe(0);
+        expect(consoleWarn.calls.length).toBe(0);
 
         renderer.render(<FormattedTime />, {intl});
-        expect(consoleError.calls.length).toBe(1);
-        expect(consoleError.calls[0].arguments[0]).toContain(
+        expect(consoleWarn.calls.length).toBe(1);
+        expect(consoleWarn.calls[0].arguments[0]).toContain(
             '[React Intl] Error formatting time.\nRangeError'
         );
     });
@@ -114,7 +114,7 @@ describe('<FormattedTime>', () => {
             <span>{String(new Date(0))}</span>
         );
 
-        expect(consoleError.calls.length).toBeGreaterThan(0);
+        expect(consoleWarn.calls.length).toBeGreaterThan(0);
     });
 
     it('accepts `format` prop', () => {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -9,12 +9,12 @@ describe('format API', () => {
     const {NODE_ENV} = process.env;
     const IRF_THRESHOLDS = {...IntlRelativeFormat.thresholds};
 
-    let consoleError;
+    let consoleWarn;
     let config;
     let state;
 
     beforeEach(() => {
-        consoleError = spyOn(console, 'error');
+        consoleWarn = spyOn(console, 'warn');
 
         config = {
             locale: 'en',
@@ -81,7 +81,7 @@ describe('format API', () => {
 
     afterEach(() => {
         process.env.NODE_ENV = NODE_ENV;
-        consoleError.restore();
+        consoleWarn.restore();
     });
 
     describe('exports', () => {
@@ -103,8 +103,8 @@ describe('format API', () => {
 
         it('fallsback and warns when no value is provided', () => {
             expect(formatDate()).toBe('Invalid Date');
-            expect(consoleError.calls.length).toBe(1);
-            expect(consoleError.calls[0].arguments[0]).toContain(
+            expect(consoleWarn.calls.length).toBe(1);
+            expect(consoleWarn.calls[0].arguments[0]).toContain(
                 '[React Intl] Error formatting date.\nRangeError'
             );
         });
@@ -112,7 +112,7 @@ describe('format API', () => {
         it('fallsback and warns when a non-finite value is provided', () => {
             expect(formatDate(NaN)).toBe('Invalid Date');
             expect(formatDate('')).toBe('Invalid Date');
-            expect(consoleError.calls.length).toBe(2);
+            expect(consoleWarn.calls.length).toBe(2);
         });
 
         it('formats falsy finite values', () => {
@@ -145,8 +145,8 @@ describe('format API', () => {
 
             it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
                 expect(formatDate(0, {year: 'invalid'})).toBe(String(new Date(0)));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     '[React Intl] Error formatting date.\nRangeError'
                 );
             });
@@ -182,8 +182,8 @@ describe('format API', () => {
                 df = new Intl.DateTimeFormat(config.locale);
 
                 expect(formatDate(date, {format})).toBe(df.format(date));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toBe(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toBe(
                     `[React Intl] No date format named: ${format}`
                 );
             });
@@ -205,8 +205,8 @@ describe('format API', () => {
 
         it('fallsback and warns when no value is provided', () => {
             expect(formatTime()).toBe('Invalid Date');
-            expect(consoleError.calls.length).toBe(1);
-            expect(consoleError.calls[0].arguments[0]).toContain(
+            expect(consoleWarn.calls.length).toBe(1);
+            expect(consoleWarn.calls[0].arguments[0]).toContain(
                 '[React Intl] Error formatting time.\nRangeError'
             );
         });
@@ -214,7 +214,7 @@ describe('format API', () => {
         it('fallsback and warns when a non-finite value is provided', () => {
             expect(formatTime(NaN)).toBe('Invalid Date');
             expect(formatTime('')).toBe('Invalid Date');
-            expect(consoleError.calls.length).toBe(2);
+            expect(consoleWarn.calls.length).toBe(2);
         });
 
         it('formats falsy finite values', () => {
@@ -247,8 +247,8 @@ describe('format API', () => {
 
             it('fallsback and warns on invalid Intl.DateTimeFormat options', () => {
                 expect(formatTime(0, {hour: 'invalid'})).toBe(String(new Date(0)));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     '[React Intl] Error formatting time.\nRangeError'
                 );
             });
@@ -282,8 +282,8 @@ describe('format API', () => {
                 const format = 'missing';
 
                 expect(formatTime(date, {format})).toBe(df.format(date));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toBe(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toBe(
                     `[React Intl] No time format named: ${format}`
                 );
             });
@@ -335,8 +335,8 @@ describe('format API', () => {
 
         it('fallsback and warns when no value is provided', () => {
             expect(formatRelative()).toBe('Invalid Date');
-            expect(consoleError.calls.length).toBe(1);
-            expect(consoleError.calls[0].arguments[0]).toContain(
+            expect(consoleWarn.calls.length).toBe(1);
+            expect(consoleWarn.calls[0].arguments[0]).toContain(
                 '[React Intl] Error formatting relative time.\nRangeError'
             );
         });
@@ -344,7 +344,7 @@ describe('format API', () => {
         it('fallsback and warns when a non-finite value is provided', () => {
             expect(formatRelative(NaN)).toBe('Invalid Date');
             expect(formatRelative('')).toBe('Invalid Date');
-            expect(consoleError.calls.length).toBe(2);
+            expect(consoleWarn.calls.length).toBe(2);
         });
 
         it('formats falsy finite values', () => {
@@ -387,8 +387,8 @@ describe('format API', () => {
 
             it('fallsback and wanrs on invalid IntlRelativeFormat options', () => {
                 expect(formatRelative(0, {units: 'invalid'})).toBe(String(new Date(0)));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toBe(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toBe(
                     '[React Intl] Error formatting relative time.\nError: "invalid" is not a valid IntlRelativeFormat `units` value, it must be one of: "second", "minute", "hour", "day", "month", "year"'
                 );
             });
@@ -424,8 +424,8 @@ describe('format API', () => {
                 rf = new IntlRelativeFormat(config.locale);
 
                 expect(formatRelative(date, {format})).toBe(rf.format(date, {now}));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toBe(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toBe(
                     `[React Intl] No relative format named: ${format}`
                 );
             });
@@ -446,7 +446,7 @@ describe('format API', () => {
                 it('does not throw or warn when a non-finite value is provided', () => {
                     expect(() => formatRelative(0, {now: NaN})).toNotThrow();
                     expect(() => formatRelative(0, {now: ''})).toNotThrow();
-                    expect(consoleError.calls.length).toBe(0);
+                    expect(consoleWarn.calls.length).toBe(0);
                 });
 
                 it('formats falsy finite values', () => {
@@ -523,8 +523,8 @@ describe('format API', () => {
 
             it('fallsback and warns on invalid Intl.NumberFormat options', () => {
                 expect(formatNumber(0, {style: 'invalid'})).toBe(String(0));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     '[React Intl] Error formatting number.\nRangeError'
                 );
             });
@@ -560,8 +560,8 @@ describe('format API', () => {
                 nf = new Intl.NumberFormat(config.locale);
 
                 expect(formatNumber(num, {format})).toBe(nf.format(num));
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toBe(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toBe(
                     `[React Intl] No number format named: ${format}`
                 );
             });
@@ -730,8 +730,8 @@ describe('format API', () => {
                     defaultMessage: messages.with_arg,
                 }, values)).toBe(mf.format(values));
 
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Missing message: "${id}" for locale: "${locale}", using default message as fallback.`
                 );
             });
@@ -746,11 +746,11 @@ describe('format API', () => {
                     defaultMessage: messages.missing,
                 }, values)).toBe(id);
 
-                expect(consoleError.calls.length).toBe(2);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(2);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Missing message: "${id}" for locale: "${locale}"`
                 );
-                expect(consoleError.calls[1].arguments[0]).toContain(
+                expect(consoleWarn.calls[1].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message id as fallback.`
                 );
             });
@@ -766,8 +766,8 @@ describe('format API', () => {
                     defaultMessage: messages.with_arg,
                 }, values)).toBe(mf.format(values));
 
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Error formatting message: "${id}" for locale: "${locale}", using default message as fallback.`
                 );
             });
@@ -783,8 +783,8 @@ describe('format API', () => {
                     defaultMessage: messages.with_arg,
                 }, values)).toBe(mf.format(values));
 
-                expect(consoleError.calls.length).toBe(1);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(1);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Error formatting message: "${id}" for locale: "${locale}", using default message as fallback.`
                 );
             });
@@ -798,14 +798,14 @@ describe('format API', () => {
                     defaultMessage: messages.invalid,
                 })).toBe(messages[id]);
 
-                expect(consoleError.calls.length).toBe(3);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(3);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Error formatting message: "${id}" for locale: "${locale}"`
                 );
-                expect(consoleError.calls[1].arguments[0]).toContain(
+                expect(consoleWarn.calls[1].arguments[0]).toContain(
                     `[React Intl] Error formatting the default message for: "${id}"`
                 );
-                expect(consoleError.calls[2].arguments[0]).toContain(
+                expect(consoleWarn.calls[2].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message source as fallback.`
                 );
             });
@@ -819,11 +819,11 @@ describe('format API', () => {
                     defaultMessage: messages.missing,
                 })).toBe(messages[id]);
 
-                expect(consoleError.calls.length).toBe(2);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(2);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Error formatting message: "${id}" for locale: "${locale}"`
                 );
-                expect(consoleError.calls[1].arguments[0]).toContain(
+                expect(consoleWarn.calls[1].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message source as fallback.`
                 );
             });
@@ -839,14 +839,14 @@ describe('format API', () => {
                     defaultMessage: messages.invalid,
                 })).toBe(messages.invalid);
 
-                expect(consoleError.calls.length).toBe(3);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(3);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Missing message: "${id}" for locale: "${locale}", using default message as fallback.`
                 );
-                expect(consoleError.calls[1].arguments[0]).toContain(
+                expect(consoleWarn.calls[1].arguments[0]).toContain(
                     `[React Intl] Error formatting the default message for: "${id}"`
                 );
-                expect(consoleError.calls[2].arguments[0]).toContain(
+                expect(consoleWarn.calls[2].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message source as fallback.`
                 );
             });
@@ -856,11 +856,11 @@ describe('format API', () => {
 
                 expect(formatMessage({id: id})).toBe(id);
 
-                expect(consoleError.calls.length).toBe(2);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(2);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Missing message: "${id}" for locale: "${config.locale}"`
                 );
-                expect(consoleError.calls[1].arguments[0]).toContain(
+                expect(consoleWarn.calls[1].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message id as fallback.`
                 );
             });
@@ -874,11 +874,11 @@ describe('format API', () => {
                     defaultMessage: messages[id],
                 })).toBe(id);
 
-                expect(consoleError.calls.length).toBe(2);
-                expect(consoleError.calls[0].arguments[0]).toContain(
+                expect(consoleWarn.calls.length).toBe(2);
+                expect(consoleWarn.calls[0].arguments[0]).toContain(
                     `[React Intl] Missing message: "${id}" for locale: "${locale}"`
                 );
-                expect(consoleError.calls[1].arguments[0]).toContain(
+                expect(consoleWarn.calls[1].arguments[0]).toContain(
                     `[React Intl] Cannot format message: "${id}", using message id as fallback.`
                 );
             });


### PR DESCRIPTION
To prevent React Native from crashing in dev environment without locale being loaded to `IntlProvider`
Closes #1120 