### PR TITLE
Support Short Relative Formats.  Fixes #393

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -37,6 +37,11 @@ function updateRelativeFormatThresholds(newThresholds) {
     hour: thresholds.hour,
     day: thresholds.day,
     month: thresholds.month,
+    'second-short': thresholds['second-short'],
+    'minute-short': thresholds['minute-short'],
+    'hour-short': thresholds['hour-short'],
+    'day-short': thresholds['day-short'],
+    'month-short': thresholds['month-short']
   } = newThresholds);
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -90,7 +90,8 @@ export const numberFormatPropTypes = {
 
 export const relativeFormatPropTypes = {
   style: oneOf(['best fit', 'numeric']),
-  units: oneOf(['second', 'minute', 'hour', 'day', 'month', 'year']),
+  units: oneOf(['second', 'minute', 'hour', 'day', 'month', 'year',
+    'second-short', 'minute-short', 'hour-short', 'day-short', 'month-short', 'year-short']),
 };
 
 export const pluralFormatPropTypes = {

--- a/test/unit/format.js
+++ b/test/unit/format.js
@@ -366,6 +366,11 @@ describe('format API', () => {
             expect(formatRelative(timestamp)).toBe(rf.format(timestamp, {now}));
         });
 
+        it('formats with short format', () => {
+            const timestamp = now - (1000 * 59);
+            expect(formatRelative(timestamp, {units: 'second-short'})).toBe('59 sec. ago');
+        });
+
         it('formats with the expected thresholds', () => {
             const timestamp = now - (1000 * 59);
             expect(IntlRelativeFormat.thresholds).toEqual(IRF_THRESHOLDS);
@@ -383,6 +388,7 @@ describe('format API', () => {
 
             it('accepts valid IntlRelativeFormat options', () => {
                 expect(() => formatRelative(0, {units: 'second'})).toNotThrow();
+                expect(() => formatRelative(0, {units: 'second-short'})).toNotThrow();
             });
 
             it('falls back and warns on invalid IntlRelativeFormat options', () => {


### PR DESCRIPTION
resolve #393

Open up Short Format options on `formatRelative`.  Completes efforts linked from related issue https://github.com/yahoo/react-intl/issues/393

Tests added and updated for short format.

Finally, once merge, related wiki needs to be updated: https://github.com/yahoo/react-intl/wiki/API#formatrelative
