### PR TITLE
release v2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Internationalize React apps. This library provides React components and an API to format dates, numbers, and strings, including pluralization and handling translations.",
   "keywords": [
     "intl",


### PR DESCRIPTION
- Doesn't throw when `FormattedMessage` has `defaultMessage` #1171