### PR TITLE
Fixes the ability to pass onError through IntlProvider

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -31,6 +31,8 @@ export const intlConfigPropTypes = {
 
   defaultLocale: string,
   defaultFormats: object,
+
+  onError: func,
 };
 
 export const intlFormatPropTypes = {

--- a/test/unit/components/provider.js
+++ b/test/unit/components/provider.js
@@ -167,6 +167,8 @@ describe('<IntlProvider>', () => {
 
             defaultLocale : 'en-US',
             defaultFormats: {},
+
+            onError: consoleError
         };
 
         const el = (
@@ -275,6 +277,8 @@ describe('<IntlProvider>', () => {
                     },
                 },
             },
+
+            onError: consoleError
         };
 
         const parentIntlProvider = new IntlProvider(props, {});


### PR DESCRIPTION
Recently v2.7.0 was released including #880, however passing a onError function through IntlProvider was broken because it got filtered out in `getConfig`. This PR fixes that.