### PR TITLE
Make react-intl react 16 compatible

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -50,7 +50,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
         <WrappedComponent
           {...this.props}
           {...{[intlPropName]: this.context.intl}}
-          ref={withRef ? (ref => this._wrappedInstance = ref) : null}
+          ref={withRef ? /* istanbul ignore next */ (ref => this._wrappedInstance = ref) : null}
         />
       );
     }

--- a/src/inject.js
+++ b/src/inject.js
@@ -42,7 +42,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
           '`injectIntl()`'
       );
 
-      return this.refs.wrappedInstance;
+      return this._wrappedInstance;
     }
 
     render() {
@@ -50,7 +50,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
         <WrappedComponent
           {...this.props}
           {...{[intlPropName]: this.context.intl}}
-          ref={withRef ? 'wrappedInstance' : null}
+          ref={withRef ? (ref => this._wrappedInstance = ref) : null}
         />
       );
     }


### PR DESCRIPTION
Closes #1078
This is not a breaking change since the access of the ref is used when calling getWrappedInstance()

In order to support React 16. We need to remove the legacy way of using ref's by setting a string.
This is now marked as legacy.

```
We advise against it because string refs have some issues, are considered legacy, and are likely to be removed in one of the future releases. 

Note

If you’re currently using this.refs.textInput to access refs, we recommend using either the callback pattern or the createRef API.
```

https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs