### PR TITLE
Fix PropType of Formatted{,HTML}Message to accept any component

### DIFF
--- a/src/components/html-message.js
+++ b/src/components/html-message.js
@@ -23,7 +23,11 @@ export default class FormattedHTMLMessage extends Component {
   static propTypes = {
     ...messageDescriptorPropTypes,
     values: PropTypes.object,
-    tagName: PropTypes.string,
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.shape({render: PropTypes.func.isRequired}),
+    ]),
     children: PropTypes.func,
   };
 

--- a/src/components/message.js
+++ b/src/components/message.js
@@ -40,7 +40,11 @@ export default class FormattedMessage extends Component {
   static propTypes = {
     ...messageDescriptorPropTypes,
     values: PropTypes.object,
-    tagName: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.shape({render: PropTypes.func.isRequired}),
+    ]),
     children: PropTypes.func,
   };
 

--- a/test/unit/components/html-message.js
+++ b/test/unit/components/html-message.js
@@ -190,6 +190,26 @@ describe('<FormattedHTMLMessage>', () => {
         );
     });
 
+    it('accepts a react component as `tagName` prop', () => {
+        const {intl} = intlProvider.getChildContext();
+        const descriptor = {
+            id: 'hello',
+            defaultMessage: 'Hello, World!',
+        };
+
+        const H1 = (children) => <h1>{children}</h1>
+        const el = <FormattedHTMLMessage {...descriptor} tagName={H1} />;
+
+        renderer.render(el, {intl});
+        expect(renderer.getRenderOutput()).toEqualJSX(
+            <H1
+                dangerouslySetInnerHTML={{
+                    __html: intl.formatHTMLMessage(descriptor),
+                }}
+            />
+        );
+    });
+
     it('supports function-as-child pattern', () => {
         const {intl} = intlProvider.getChildContext();
         const descriptor = {

--- a/test/unit/components/message.js
+++ b/test/unit/components/message.js
@@ -205,7 +205,7 @@ describe('<FormattedMessage>', () => {
         );
     });
 
-    it('accepts an react element as `tagName` prop', () => {
+    it('accepts a react component as `tagName` prop', () => {
         const {intl} = intlProvider.getChildContext();
         const descriptor = {
             id: 'hello',


### PR DESCRIPTION
A React component is not the same as a React element! In our case, the tagName prop can be anything that can be passed to React.createElement(). Unfortunately the prop-types package doesn't provide a suitable validation function, so people are forced to build their own.

See https://github.com/facebook/prop-types/issues/200 for a related discussion.