### PR TITLE
Update to CLDR 34

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "expect": "^1.9.0",
     "expect-jsx": "^3.0.0",
     "express": "^4.13.3",
-    "formatjs-extract-cldr-data": "^4.0.0",
+    "formatjs-extract-cldr-data": "^6.0.0",
     "glob": "^7.0.0",
     "intl": "^1.2.1",
     "intl-messageformat-parser": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,17 +1166,20 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cldr-core@^31.0.1:
-  version "31.0.1"
-  resolved "https://registry.yarnpkg.com/cldr-core/-/cldr-core-31.0.1.tgz#24b3d59359ef890595665e5a8ca29e53901c6d54"
+cldr-core@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/cldr-core/-/cldr-core-34.0.0.tgz#2e9d1f9909868e93e70c4813a74f331af028d66c"
+  integrity sha512-PFHHn2SlqRdqD1ZC8Ddw5ZOSwJdqsmTY6fnOVsX5iMfOShqXs7QhpkIo4eOvz7rFdEivp/IrMDPs47Z4z1rD3g==
 
-cldr-dates-full@^31.0.1:
-  version "31.0.1"
-  resolved "https://registry.yarnpkg.com/cldr-dates-full/-/cldr-dates-full-31.0.1.tgz#c49a4740250646148cfb55e02f20d7ae2c917f89"
+cldr-dates-full@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/cldr-dates-full/-/cldr-dates-full-34.0.0.tgz#e2f9c254ab7d6b0a5d28481737138530eebb3be6"
+  integrity sha512-mKGQF16YAEeMOlTA1oT8vWOnm2VuCE1yGQQN7CbnKirVhXigoa0uUiOwjajCZSVpLMyTwWi8AvlY1pjNlX6uRw==
 
-cldr-numbers-full@^31.0.1:
-  version "31.0.1"
-  resolved "https://registry.yarnpkg.com/cldr-numbers-full/-/cldr-numbers-full-31.0.1.tgz#a78774e1544fbf9616d8f6812a312b10f4aaafbe"
+cldr-numbers-full@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/cldr-numbers-full/-/cldr-numbers-full-34.0.0.tgz#f9e62bd4dda1fb4e17c7a3e4b170da2263f43dac"
+  integrity sha512-+Bqxnym5Fv81u/iBoZvy2dUfPQdAc4KbX4QDptq9PLx846iQkRN0UKo3t5xZu97rUlRw2fFGaRt+KO6iMPo+RA==
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -2064,13 +2067,14 @@ form-data@^2.1.1, form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatjs-extract-cldr-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/formatjs-extract-cldr-data/-/formatjs-extract-cldr-data-4.0.0.tgz#72b8c36f92a855989a381fa6c194566b34a1539f"
+formatjs-extract-cldr-data@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/formatjs-extract-cldr-data/-/formatjs-extract-cldr-data-6.0.0.tgz#f05b6fe758ae109c1ee0b33c0c17781fe9cfb29b"
+  integrity sha512-5AldF5PJMDi9Offq59NP7pswzEj3+ThiZcZY0mJ0DZINn3TZHrjx7jwewb4+G6c+3fTLt7KVl9SGc8qpet8j5w==
   dependencies:
-    cldr-core "^31.0.1"
-    cldr-dates-full "^31.0.1"
-    cldr-numbers-full "^31.0.1"
+    cldr-core "^34.0.0"
+    cldr-dates-full "^34.0.0"
+    cldr-numbers-full "^34.0.0"
     glob "^5.0.1"
     make-plural "^2.1.3"
     object.assign "^4.0.3"


### PR DESCRIPTION
This upgrades the formatjs-extract-cldr-data from v4.0.0 to v6.0.0.

It includes following changes.

- CLDR 34: http://cldr.unicode.org/index/downloads/cldr-34
- CLDR 33: http://cldr.unicode.org/index/downloads/cldr-33
- CLDR 32: http://cldr.unicode.org/index/downloads/cldr-32

Fixes: #1229